### PR TITLE
Fix leaking a Lua object reference when a managed Lua object wrapper is finalized without being disposed

### DIFF
--- a/Core/NLua/LuaBase.cs
+++ b/Core/NLua/LuaBase.cs
@@ -56,10 +56,8 @@ namespace NLua
 		public virtual void Dispose (bool disposeManagedResources)
 		{
 			if (!_Disposed) {
-				if (disposeManagedResources) {
-					if (_Reference != 0)
-						_Interpreter.dispose (_Reference);
-				}
+				if (_Reference != 0)
+					_Interpreter.dispose (_Reference);
 
 				_Interpreter = null;
 				_Disposed = true;


### PR DESCRIPTION
(Was https://github.com/NLua/NLua/issues/7)
