### PR TITLE
Fix leaking a Lua object reference when a managed Lua object wrapper is finalized without being disposed

### DIFF
--- a/Core/NLua/LuaBase.cs
+++ b/Core/NLua/LuaBase.cs
@@ -56,10 +56,8 @@ namespace NLua
 		public virtual void Dispose (bool disposeManagedResources)
 		{
 			if (!_Disposed) {
-				if (disposeManagedResources) {
-					if (_Reference != 0)
-						_Interpreter.dispose (_Reference);
-				}
+				if (_Reference != 0)
+					_Interpreter.dispose (_Reference);
 
 				_Interpreter = null;
 				_Disposed = true;


### PR DESCRIPTION
(Was https://github.com/NLua/NLua/pull/10)

I have reworked my previous patch to instead maintain a queue of references that need to be unref'd on the proper thread.  Right now the queue is processed on every call to `DoString()`/`DoFile()`.

As per the comments on my commit, it would be nicer if we could register a callback with `lua_sethook()` and process the queue every N steps; this will keep long-running Lua scripts from keeping dead objects from being collected.

On the other hand, since Lua is not thread-safe on this level, managed object wrappers shouldn't be manipulated while a script is running -- nevertheless, we don't have control over the finalizer and so we can't guarantee that finalization of a wrapper object won't happen at an inopportune moment.  The queue prevents the untimely finalization of a managed wrapper from causing a segfault, at the expense of having to wait until the next script invocation to clean up these references.  This seems like an acceptable compromise to me.

I did run the test suite this time ;) and it completed successfully.
