### PR TITLE
Cache member in SetMemberCache

### DIFF
--- a/Core/NLua/Metatables.cs
+++ b/Core/NLua/Metatables.cs
@@ -517,6 +517,8 @@ namespace NLua
 				members = new Dictionary<object, object>();
 				memberCache[objType] = members;
 			}
+
+			members [memberName] = member;
 		}
 
 		/*


### PR DESCRIPTION
SetMemberCache was no longer caching the member passed to it. This was causing performance problems, in which a script was taking 3-4 times longer to run than without proper caching. There was a missing line SetMemberCache which fixed the issue.

A concern with this change is the offending line was removed during a refactor, in which the commit message said "fixing generic exceptions". I do not know which generic exceptions were fixed during that commit, and don't know if breaking caching, or removing this line was intentional.
