### PR TITLE
Structures that hash to the same value are sharing values.

### DIFF
--- a/tests/LuaTests.cs
+++ b/tests/LuaTests.cs
@@ -120,6 +120,20 @@ namespace NLuaTest
 		}
 
 		[Test]
+		public void TestStructHashesEqual()
+		{
+			using (Lua lua = new Lua())
+			{
+				lua.DoString("luanet.load_assembly('NLuaTest')");
+				lua.DoString("TestStruct=luanet.import_type('NLuaTest.Mock.TestStruct')");
+				lua.DoString("struct1=TestStruct(0)");
+				lua.DoString("struct2=TestStruct(0)");
+				lua.DoString("struct2.val=1");
+				Assert.AreEqual(0, (double)lua["struct1.val"]);
+			}
+		}
+
+		[Test]
 		public void TestMethodOverloads ()
 		{
 			using (Lua lua = new Lua ()) {


### PR DESCRIPTION
I added a unit test "TestStructHashesEqual" that is currently failing, so
that someone can investigate.

I believe the reason for this is structs usually hash to the save values if their member values are the same. The objectsBackMap in ObjectTranslator is a dictionary, which probably uses GetHashCode() to store 'unique' instances in the dictionary. However because the structures hash to the same value, they both get written to the same slot.
