### PR TITLE
Type search finds classes not declared in a namespace.

### DIFF
--- a/Core/NLua/Lua.cs
+++ b/Core/NLua/Lua.cs
@@ -171,6 +171,7 @@ local mt = {
 		local class = rawget(package, classname)
 		if class == nil then
 			class = import_type(package.packageName .. ""."" .. classname)
+			if class == nil then class = import_type(classname) end
 			package[classname] = class		-- keep what we found around, so it will be shared
 		end
 		return class


### PR DESCRIPTION
Yo!

Most Unity3D users don't declare their classes inside a namespace. Unity doesn't require classes to be inside a namespace, and their default behaviour template doesn't include one. This is ostensibly to make C# more approachable to scripters & non-software developers (A large block of Unity's userbase).

This additional line in the clr package script checks if a type can be found in the 'global' namespace if searching for the namespace qualified type fails.
