### PR TITLE
Create structs with default parameterless constructor

### DIFF
--- a/Core/NLua/Metatables.cs
+++ b/Core/NLua/Metatables.cs
@@ -1114,11 +1114,9 @@ namespace NLua
 				}
 			}
 
-			if (klass.UnderlyingSystemType.IsValueType)
-			{
+			if (klass.UnderlyingSystemType.IsValueType) {
 				int numLuaParams = LuaLib.LuaGetTop (luaState);
-				if (numLuaParams == 0)
-				{
+				if (numLuaParams == 0) {
 					translator.Push (luaState, Activator.CreateInstance (klass.UnderlyingSystemType));
 					return 1;
 				}

--- a/tests/LuaTests.cs
+++ b/tests/LuaTests.cs
@@ -214,9 +214,9 @@ namespace NLuaTest
 			}
 		}
 
-        /*
-        * Tests structure creation via the default constructor
-        */
+		/*
+		* Tests structure creation via the default constructor
+		*/
 		[Test]
 		public void TestStructDefaultConstructor ()
 		{
@@ -225,6 +225,7 @@ namespace NLuaTest
 				lua.DoString ("luanet.load_assembly('NLuaTest')");
 				lua.DoString ("TestStruct=luanet.import_type('NLuaTest.Mock.TestStruct')");
 				lua.DoString ("struct=TestStruct()");
+				Assert.AreEqual (new TestStruct(), (TestStruct)lua ["struct"]);
 			}
 		}
 


### PR DESCRIPTION
Hi,

This pull request is intended to fix an issue where NLua does not create structs (or other value types) using the default, parameterless constructor. It detects when a valuetype doesn't find a constructor with zero parameters and instead uses Activator to create the object.

Thanks,
Isaac
