### PR TITLE
Added 'AllowReflection' to permit or deny access to object.GetType()

### DIFF
--- a/Core/NLua/Lua.cs
+++ b/Core/NLua/Lua.cs
@@ -97,6 +97,12 @@ namespace NLua
 		/// </summary>
 		public bool IsExecuting { get { return executing; } }
 
+		private bool _AllowReflection = true;
+		/// <summary>
+		/// Whether to allow or deny access to the GetType() function on .Net objects
+		/// </summary>
+		public bool AllowReflection { get { return _AllowReflection; } set { _AllowReflection = value; } }
+
 		private LuaNativeFunction panicCallback;
 		private ObjectTranslator translator;
 		/// <summary>

--- a/Core/NLua/Method/LuaMethodWrapper.cs
+++ b/Core/NLua/Method/LuaMethodWrapper.cs
@@ -276,8 +276,13 @@ namespace NLua.Method
 			}
 
 			if (failedCall) {
-				if (!LuaLib.LuaCheckStack (luaState, _LastCalledMethod.outList.Length + 6))
+				if (!LuaLib.LuaCheckStack (luaState, _LastCalledMethod.outList.Length + 6))	
 					throw new LuaException ("Lua stack overflow");
+
+				if (!_Translator.interpreter.AllowReflection) {
+					if (_LastCalledMethod.cachedMethod.MethodHandle == typeof (Object).GetMethod ("GetType").MethodHandle)
+						throw new LuaException ("Reflection is not supported");
+				}
 
 				try {
 					if (isStatic)


### PR DESCRIPTION
I implemented this for use in my program. Perhaps it will be useful in the main branch as well.