### PR TITLE
An attribute for checking permissions: LuaPermission

### DIFF
--- a/Core/NLua/LuaPermissionAttribute.cs
+++ b/Core/NLua/LuaPermissionAttribute.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * This file is part of NLua.
+ * 
+ * Copyright (c) 2014 Vinicius Jarina (viniciusjarina@gmail.com)
+ * Copyright (C) 2003-2005 Fabio Mascarenhas de Queiroz.
+ * Copyright (C) 2012 Megax <http://megax.yeahunter.hu/>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+using System;
+using System.Reflection;
+
+namespace NLua
+{
+	/// <summary>
+	/// Marks a method, field or property to only be usable if the given callback returns true.
+	/// Callback must return a bool.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
+	public sealed class LuaPermissionAttribute : Attribute
+	{
+		internal Type type;
+		internal string funcName;
+		internal object[] funcParams;
+
+		/// <summary>
+		/// Message to show in the exception if access is not allowed
+		/// </summary>
+		public string Message { get; set; }
+
+		public LuaPermissionAttribute(Type type, string funcName)
+		{
+			this.type = type;
+			this.funcName = funcName;
+			this.funcParams = null;
+			this.Message = "Access denied";
+		}
+
+		public LuaPermissionAttribute(Type type, string funcName, params object[] funcParams)
+		{
+			this.type = type;
+			this.funcName = funcName;
+			this.funcParams = funcParams;
+			this.Message = "Access denied";
+		}
+
+		/// <summary>
+		/// Check whether Lua is allowed to access this member
+		/// </summary>
+		/// <param name="obj">The object on which to apply the callback function</param>
+		/// <returns>True if allowed, false if not</returns>
+		public bool Allowed(object obj)
+		{
+			BindingFlags bf = (BindingFlags)65535; // everything, so that we can get internal and private callback methods
+			MethodInfo mi = this.type.GetMethod (this.funcName, bf);
+			if (mi == null)
+				throw new Exception ("Lua permission callback not found: '" + this.funcName + "'");
+			return (bool)mi.Invoke (obj, this.funcParams);
+		}
+	}
+}

--- a/Core/NLua/Metatables.cs
+++ b/Core/NLua/Metatables.cs
@@ -599,6 +599,18 @@ namespace NLua
 				}
 			}
 
+			// check if we have permission or not
+			object[] attributes = member.GetCustomAttributes (typeof (LuaPermissionAttribute), true);
+			bool blocked = false;
+			foreach (LuaPermissionAttribute attr in attributes) {
+				if (!attr.Allowed (obj)) {
+					member = null;
+					blocked = true;
+					ThrowError (luaState, new Exception (attr.Message));
+					break;
+				}
+			}
+
 			if (member != null) {
 #if NETFX_CORE
 				if (member is FieldInfo) {
@@ -691,7 +703,7 @@ namespace NLua
 					translator.ThrowError (luaState, "can't pass instance to static method " + methodName);
 					LuaLib.LuaPushNil (luaState);
 				}
-			} else {
+			} else if (!blocked) {
 
 				if (objType.UnderlyingSystemType != typeof(object)) {
 					#if NETFX_CORE

--- a/Core/NLua/NLua.Net40.csproj
+++ b/Core/NLua/NLua.Net40.csproj
@@ -72,6 +72,7 @@
     <Compile Include="LuaFunction.cs" />
     <Compile Include="LuaGlobalAttribute.cs" />
     <Compile Include="LuaHideAttribute.cs" />
+    <Compile Include="LuaPermissionAttribute.cs" />
     <Compile Include="LuaRegistrationHelper.cs" />
     <Compile Include="LuaTable.cs" />
     <Compile Include="LuaUserData.cs" />


### PR DESCRIPTION
Here is an implementation I wrote in order to dynamically control what's accessible from Lua scripts.

For example, I can have the following class defined:

```C#
public class SomeClass
{
  public string SomeText = "";
  public void SetText(string strText)
  {
    SomeText = strText;
  }
}
```

We can now attach a `LuaPermission` attribute to `SomeText` and `SetText`, like this:

```C#
[LuaPermission(typeof(SomeClass), "CanUse")]
public string SomeText = "";
[LuaPermission(typeof(SomeClass), "CanUse")]
public void SetText(string strText)
```

When you try to access `SomeText` or call `SetText` from Lua:

```Lua
someObject.SomeText = "test"
someObject:SetText("test")
```

NLua will call a method `CanUse` inside of `SomeClass` to check whether it actually has the permissions to carry on the execution:

```C#
internal bool CanUse()
{
  return true;
}
```

If we return true here, execution carries on like normal. If we return false here, a Lua error will be thrown. (Optionally, the error message can be changed in the attribute.)

Thoughts?