### PR TITLE
Indexer performance improvement

### DIFF
--- a/Core/NLua/Metatables.cs
+++ b/Core/NLua/Metatables.cs
@@ -756,7 +756,7 @@ namespace NLua
 		}
 
 		/*
-		 * Checks if a MemberInfo object is cached. Returns the object or null if the object is not found.
+		 * Checks if a MemberInfo object is cached, returning it or null.
 		 */
 		object CheckMemberCache (Dictionary<object, object> memberCache, Type objType, object memberName)
 		{
@@ -771,8 +771,9 @@ namespace NLua
 			{
 				var membersDict = members as Dictionary<object, object>;
 
-				object memberValue;
-				if (members != null && membersDict.TryGetValue (memberName, out memberValue))
+				object memberValue = null;
+
+				if (members != null && membersDict.TryGetValue(memberName, out memberValue))
 					return memberValue;
 			}
 
@@ -904,7 +905,7 @@ namespace NLua
 			}
 
 			// Find our member via reflection or the cache
-			var member = CheckMemberCache (memberCache, targetType, fieldName) as MemberInfo;
+			var member = (MemberInfo)CheckMemberCache (memberCache, targetType, fieldName);
 			if (member == null) {
 				var members = targetType.GetMember (fieldName, bindingType | BindingFlags.Public);
 

--- a/Core/NLua/Metatables.cs
+++ b/Core/NLua/Metatables.cs
@@ -444,7 +444,7 @@ namespace NLua
 				if (items != null) {
 					foreach (var item in items) {
 						var propInfo = item as PropertyInfo;
-						if (propInfo != null) {
+						if (propInfo != null && propInfo.CanRead == true) {
 							var parameters = propInfo.GetIndexParameters ();
 							if (parameters != null && parameters.Length == 1) {
 								ExtractValue extractor;

--- a/Core/NLua/ObjectTranslator.cs
+++ b/Core/NLua/ObjectTranslator.cs
@@ -345,6 +345,11 @@ namespace NLua
 			return type.GetExtensionMethod (name, assemblies);
 		}
 
+		public MethodInfo[] GetExtensionMethods (Type type)
+		{
+			return type.GetExtensionMethods (assemblies);
+		}
+
 		/*
 		 * Implementation of import_type. Returns nil if the
 		 * type is not found.


### PR DESCRIPTION
Changed the handling of extension methods in Metatables.cs (IsExtensionMethodPresent and GetExtensionMethod), as well as indexers in GetMethodInternal, to dramatically improve the performance of indexers. The problem was that indexer keys are not cached in the member cache so reflection was being done on the key name for methods and extension methods every time an indexer was used. The extension method search, in particular, was very costly. The change allows the extension method search to be avoided after the first use of any indexer.