### PR TITLE
  Remove translator from the global pool before Lua state is closed

### DIFF
--- a/Core/NLua/Lua.cs
+++ b/Core/NLua/Lua.cs
@@ -329,8 +329,8 @@ end
 				return;
 
 			if (! CheckNull.IsNull(luaState)) {
-				LuaCore.LuaClose (luaState);
 				ObjectTranslatorPool.Instance.Remove (luaState);
+				LuaCore.LuaClose (luaState);
 			}
 		}
 


### PR DESCRIPTION
Need to remove the translator from the global dictionary before LuaState is closed to avoid race condition, where another LuaState instance can be created at the same address and added to the dictionary before the old one is removed. 