### PR TITLE
fix unicode characters support in DoString

### DIFF
--- a/Core/NLua/LuaLib/LuaLib.cs
+++ b/Core/NLua/LuaLib/LuaLib.cs
@@ -26,6 +26,7 @@
  */
 using System;
 using System.IO;
+using System.Text;
 using NLua.Extensions;
 
 namespace NLua
@@ -384,7 +385,8 @@ namespace NLua
 
 		public static int LuaLLoadBuffer (LuaState luaState, string buff, string name)
 		{
-			return LuaCore.LuaNetLoadBuffer (luaState, buff, (uint)0, name);
+			var bytes = Encoding.UTF8.GetBytes(buff);
+			return LuaCore.LuaNetLoadBuffer (luaState, bytes, (uint)bytes.Length, name);
 		}
 
 		public static int LuaLLoadBuffer (LuaState luaState, byte [] buff, string name)

--- a/tests/LuaTests.cs
+++ b/tests/LuaTests.cs
@@ -157,6 +157,13 @@ namespace NLuaTest
 				return Convert.ToString (UnicodeChar);
 			}
 		}
+		public static string UnicodeStringRussian
+		{
+			get
+			{
+				return "Файл";
+			}
+		}
 		/*
         * Tests capturing an exception
         */
@@ -2062,6 +2069,17 @@ namespace NLuaTest
 				string res = (string)lua ["res"];
 
 				Assert.AreEqual (LuaTests.UnicodeString, res);
+			}
+		}
+
+		[Test]
+		public void TestUnicodeCharsInDoString()
+		{
+			using (Lua lua = new Lua ()) {
+				lua.DoString("res = 'Файл'");
+				string res = (string)lua["res"];
+
+				Assert.AreEqual(LuaTests.UnicodeStringRussian, res);
 			}
 		}
 


### PR DESCRIPTION
This is effectively fix for issue #48.

In current implementation, if I call `DoString` with Unicode characters, all characters will be marshaled with `CharSet.Ansi`. It effectively will convert all unicode characters to ANSI '?' (question mark).

Using `Encoding.UTF8.GetBytes()` will convert source string to correct bytes for chunk.
I agreed with http://utf8everywhere.org/ and belive that UTF8 is right encoding for all.