### PR TITLE
Fixed issue where variadic static method arguments wouldn't get read …

### DIFF
--- a/Core/NLua/Method/LuaMethodWrapper.cs
+++ b/Core/NLua/Method/LuaMethodWrapper.cs
@@ -169,7 +169,7 @@ namespace NLua.Method
 								};
 
 								if (_LastCalledMethod.argTypes [i].isParamsArray) {
-									int count = index - _LastCalledMethod.argTypes.Length;
+									int count = _LastCalledMethod.argTypes.Length - i;
 									Array paramArray = _Translator.TableToArray (valueExtractor, type.paramsArrayType, index, count);
 									args [_LastCalledMethod.argTypes [i].index] = paramArray;
 								} else {


### PR DESCRIPTION
…from cache properly

* The count of cached parameters was done wrong (I assume), so the parameter array was empty when calling a static method more than once with a variadic parameter array for some reasons.

The best way to spot the issues immediately is to try to wrap "String.Format(string, params object[])" in a static class method "Format(string, params object[])". And then call it twice in a row with any valid paramters. The second time, the parameter array will be completely empty even if data was passed to the function inside the lua script.

Here's the code I used to test the issue, and the fix:

C#

```
using System;
using System.Collections.Generic;
using NLua;

namespace NLUA_SANDBOX
{
    public class Test2
    {
        public static string Format(string fmt, params object[] para)
        {
            return String.Format(System.Text.RegularExpressions.Regex.Unescape(fmt), para);
        }

        public static string Format2(params object[] para)
        {
            return String.Format(System.Text.RegularExpressions.Regex.Unescape((string)para[0]), para[1]);
        }

        public string FormatI(string fmt, params object[] para)
        {
            return String.Format(System.Text.RegularExpressions.Regex.Unescape(fmt), para);
        }

        public string FormatI2(params object[] para)
        {
            return String.Format(System.Text.RegularExpressions.Regex.Unescape((string)para[0]), para[1]);
        }
    }

class LuaManager
    {
        public Lua m_state = new Lua();

        public LuaManager()
        {
            ImportDotNet();
        }

        private void ImportDotNet()
        {
            m_state.LoadCLRPackage();
        }

        public void CallTestFunction()
        {
            m_state.DoFile("test.lua");
        }
    }

    class Program
    {
        static void Main(string[] args)
        {
            LuaManager luaengine = new LuaManager();
            luaengine.CallTestFunction();
        }
    }
}
```

And the lua file test.lua:
```

require 'CLRPackage'
import 'System'
import 'System.String'
import 'NLUA_SANDBOX'
import 'NLUA_SANDBOX.Test2'

-- This doesn't work without the fix
local myt = Test2()
print( Test2.Format("{0}?", 'Any String') )
print( Test2.Format("{0}?", 'Any') ) -- This results in TargetInvocationException inside LuaMethodWrapper.Call

print( Test2.Format2("{0}?", 'Hi'))
print( Test2.Format2("{0}?", 'Blaah'))

print( myt:FormatI("{0}?", 'test!') )
print( myt:FormatI("{0}?", 'Any String') )

print( myt:FormatI2("{0}?", 'HEY') )
print( myt:FormatI2("{0}?", 'WHOAH') )


-- This works without the fix
print( Test2.Format("{0}?", 'Any String') )
print( Test2.Format("{0}?", 'Any', 2) ) --If we add another parameter on the second call it seems to fix the issue for any other methods..

print( Test2.Format2("{0}?", 'Hi'))
print( Test2.Format2("{0}?", 'Blaah'))

print( myt:FormatI("{0}?", 'test!') )
print( myt:FormatI("{0}?", 'Any String') )

print( myt:FormatI2("{0}?", 'HEY') )
print( myt:FormatI2("{0}?", 'WHOAH') )

```

Also, it seems like if you specify more than one variadic parameter on the second call, the issue just doesn't show up at all for the rest of the lifetime of the lua context. 

It fixed the bugs I encountered with the lib, so I thought I'd share!