### PR TITLE
Finding extention methods by interface too

### DIFF
--- a/Core/NLua/Extensions/GeneralExtensions.cs
+++ b/Core/NLua/Extensions/GeneralExtensions.cs
@@ -160,8 +160,10 @@ namespace NLua.Extensions
 						where extensionType.IsSealed() && !extensionType.IsGenericType() && !extensionType.IsNested
 						from method in extensionType.GetMethods (BindingFlags.Static | BindingFlags.Public)
 						where method.IsDefined (typeof (ExtensionAttribute), false)
-						where (method.GetParameters () [0].ParameterType == type || type.IsSubclassOf(method.GetParameters()[0].ParameterType))
-						select method;
+                        where (method.GetParameters()[0].ParameterType == type
+                            || type.IsSubclassOf(method.GetParameters()[0].ParameterType)
+                            || type.GetInterfaces().Contains(method.GetParameters()[0].ParameterType))
+                        select method;
 			return query.ToArray<MethodInfo> ();
 		}
 


### PR DESCRIPTION
When I was trying to use some extensions method from my project in Lua script I running into problem, cause extensions method was written for interface, not for type.

Example:

```
    public class UsedInLua
    {
        public string DoStuff()
        {
            return "DoStuff";
        }
    }

    public static class UsedInLuaExtentions
    {
        public static void DoStuff2(this UsedInLua dostuff)
        {
            Console.WriteLine("DoStuff2");
        }
    }

    ...

    lua["usedInLua"] = new UsedInLua();
    lua.DoString("str = usedInLua.DoStuff2()");
```

is working.  But this code:

```
    public interface IUsedInLua
    {
        string DoStuff();
    }

    public class UsedInLua : IUsedInLua
    {
        public string DoStuff()
        {
            return "DoStuff";
        }
    }

    public static class UsedInLuaExtentions
    {
        public static void DoStuff2(this IUsedInLua dostuff)
        {
            Console.WriteLine("DoStuff2");
        }
    }
```

was throwed with error "_attempt to call field '' (a string value)_"

`    lua.DoString("str2 = uilua.DoStuff2()");`

was returned 'string' instead 'userdata'.

In this PR i trying to solve this issue.
