### PR TITLE
Fix of calling methods with 'params' array when nil (null) is used as first one.

### DIFF
--- a/Core/NLua/Metatables.cs
+++ b/Core/NLua/Metatables.cs
@@ -1265,19 +1265,7 @@ namespace NLua
 				{					
 					paramList.Add (null);
 					outList.Add (paramList.LastIndexOf (null));
-				}  else if (IsTypeCorrect (luaState, currentLuaParam, currentNetParam, out extractValue)) {  // Type checking
-					var value = extractValue (luaState, currentLuaParam);
-					paramList.Add (value);
-					int index = paramList.LastIndexOf (value);
-					var methodArg = new MethodArgs ();
-					methodArg.index = index;
-					methodArg.extractValue = extractValue;
-					argTypes.Add (methodArg);
 
-					if (currentNetParam.ParameterType.IsByRef)
-						outList.Add (index);
-
-					currentLuaParam++;
 				}  // Type does not match, ignore if the parameter is optional
 				else if (IsParamsArray (luaState, nLuaParams, currentLuaParam, currentNetParam, out extractValue)) {
 
@@ -1298,9 +1286,23 @@ namespace NLua
 					methodArg.isParamsArray = true;
 					methodArg.paramsArrayType = paramArrayType;
 					argTypes.Add (methodArg);
-					 
 
-				} else if (currentLuaParam > nLuaParams) { // Adds optional parameters
+                }
+				else if (IsTypeCorrect(luaState, currentLuaParam, currentNetParam, out extractValue))
+				{  // Type checking
+				    var value = extractValue(luaState, currentLuaParam);
+				    paramList.Add(value);
+				    int index = paramList.LastIndexOf(value);
+				    var methodArg = new MethodArgs();
+				    methodArg.index = index;
+				    methodArg.extractValue = extractValue;
+				    argTypes.Add(methodArg);
+
+				    if (currentNetParam.ParameterType.IsByRef)
+				        outList.Add(index);
+
+				    currentLuaParam++;
+                } else if (currentLuaParam > nLuaParams) { // Adds optional parameters
 					if (currentNetParam.IsOptional)
 						paramList.Add (currentNetParam.DefaultValue);
 					else {

--- a/tests/LuaTests.cs
+++ b/tests/LuaTests.cs
@@ -2490,7 +2490,52 @@ namespace NLuaTest
 			}
 		}
 
-		[Test]
+	    [Test]
+	    public void TestCallMethodWithParamsOptional()
+	    {
+	        using (var l = new Lua())
+	        {
+	            l.LoadCLRPackage();
+	            l.DoString(" import ('NLuaTest','NLuaTest.Mock') ");
+	            l.DoString(@"					
+					r = TestClass.MethodWithParams(2, 7, 4)			
+				");
+	            int r = (int)l.GetNumber("r");
+	            Assert.AreEqual(2, r, "#1");
+	        }
+	    }
+
+	    [Test]
+	    public void TestCallMethodWithObjectParams()
+	    {
+	        using (var l = new Lua())
+	        {
+	            l.LoadCLRPackage();
+	            l.DoString(" import ('NLuaTest','NLuaTest.Mock') ");
+	            l.DoString(@"					
+					r = TestClass.MethodWithObjectParams(2, nil, 4, 'abc')			
+				");
+	            int r = (int)l.GetNumber("r");
+	            Assert.AreEqual(4, r, "#1");
+	        }
+	    }
+
+	    [Test]
+	    public void TestCallMethodWithObjectParamsAndNilAsFirstArgument()
+	    {
+	        using (var l = new Lua())
+	        {
+	            l.LoadCLRPackage();
+	            l.DoString(" import ('NLuaTest','NLuaTest.Mock') ");
+	            l.DoString(@"					
+					r = TestClass.MethodWithObjectParams(nil, 4, 'abc')			
+				");
+	            int r = (int)l.GetNumber("r");
+	            Assert.AreEqual(3, r, "#1");
+	        }
+	    }
+
+        [Test]
 		public void TestConstructorOverload ()
 		{
 			using (var l = new Lua ()) {

--- a/tests/TestLua.cs
+++ b/tests/TestLua.cs
@@ -614,7 +614,18 @@ namespace NLuaTest.Mock
 			}
 			return i;
 		}
-	}
+
+	    static public int MethodWithObjectParams(params object[] others)
+	    {
+	        int i = 0;
+	        foreach (var val in others)
+	        {
+	            Console.WriteLine(val);
+	            i++;
+	        }
+	        return i;
+	    }
+    }
 
 	public class TestClassWithOverloadedMethod
 	{


### PR DESCRIPTION
When someone registers method print with params array parameters which declaration might look like:
`public static void Print(params object[] data)`

Then he provide lua code  like:
`print(nil, nil)`

He will get error:
`invalid arguments to method call`

This change is only modification to order of checking parameter types. First IsParamsArray, then IsTypeCorrect.  IsParamsArray verifies ParamsAttribute and if present it must be last argument so change should not disturb execution.

May fix: https://github.com/NLua/NLua/issues/236