### PR TITLE
thread-safe

### DIFF
--- a/src/ObjectTranslator.cs
+++ b/src/ObjectTranslator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using KeraLua;
@@ -50,7 +51,7 @@ namespace NLua
         // object # to object (FIXME - it should be possible to get object address as an object #)
         readonly Dictionary<int, object> _objects = new Dictionary<int, object>();
 
-        readonly Queue<int> finalizedReferences = new Queue<int>();
+        readonly ConcurrentQueue<int> finalizedReferences = new ConcurrentQueue<int>();
 
         internal EventHandlerContainer PendingEvents = new EventHandlerContainer();
         MetaFunctions metaFunctions;

--- a/src/ObjectTranslator.cs
+++ b/src/ObjectTranslator.cs
@@ -1134,14 +1134,9 @@ namespace NLua
 
         void CleanFinalizedReferences(LuaState state)
         {
-            if (finalizedReferences.Count == 0)
-                return;
-
-            while (finalizedReferences.Count != 0)
-            {
-                int reference = finalizedReferences.Dequeue();
+            int reference;
+            while (finalizedReferences.TryDequeue(out reference))
                 state.Unref(LuaRegistry.Index, reference);
-            }
         }
     }
 }


### PR DESCRIPTION
Release NLua objects that should not be released in a multi-threaded environment