### PR TITLE
Move call to `lua_error` to the same level of the delegate callback

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -367,7 +367,7 @@ namespace NLua
                 return 0;
 
             _translator.ThrowError(_luaState, caughtExcept);
-            _luaState.PushNil();
+            //_luaState.PushNil();
             return 1;
         }
 

--- a/src/Method/LuaMethodWrapper.cs
+++ b/src/Method/LuaMethodWrapper.cs
@@ -220,7 +220,7 @@ namespace NLua.Method
                 {
                     _translator.ThrowError(luaState,
                         string.Format("instance method '{0}' requires a non null target object", _methodName));
-                    luaState.PushNil();
+                    //luaState.PushNil();
                     return 1;
                 }
 
@@ -251,7 +251,7 @@ namespace NLua.Method
                     ? "Invalid arguments to method call"
                     : ("Invalid arguments to method: " + candidateName);
                 _translator.ThrowError(luaState, msg);
-                luaState.PushNil();
+                //luaState.PushNil();
                 return 1;
             }
 
@@ -317,7 +317,7 @@ namespace NLua.Method
                 if (!_translator.MatchParameters(luaState, methodToCall,  _lastCalledMethod, 0))
                 {
                     _translator.ThrowError(luaState, "Invalid arguments to method call");
-                    luaState.PushNil();
+                    //luaState.PushNil();
                     return 1;
                 }
             }
@@ -327,7 +327,7 @@ namespace NLua.Method
                 {
                     _translator.ThrowError(luaState,
                         "Unable to invoke method on generic class as the current method is an open generic method");
-                    luaState.PushNil();
+                    //luaState.PushNil();
                     return 1;
                 }
 

--- a/src/ObjectTranslator.cs
+++ b/src/ObjectTranslator.cs
@@ -239,7 +239,7 @@ namespace NLua
             }
 
             Push(luaState, e);
-            luaState.Error();
+            //luaState.Error();
         }
 
         /*

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -2711,6 +2711,77 @@ namespace NLuaTest
             Assert.AreNotEqual(15, result, "#1");
         }
 
+        [Test]
+        public void ThrowMultipleExceptions()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua.DoString("luanet.load_assembly('mscorlib')");
+                lua.DoString("luanet.load_assembly('NLuaTest', 'NLuaTest.TestTypes')");
+                lua.DoString("TestClass = luanet.import_type('NLuaTest.TestTypes.TestClass')");
+                lua.DoString("test = TestClass()");
+                lua.DoString("err,errMsg = pcall(test.exceptionMethod,test)");
+                bool err = (bool)lua["err"];
+
+                var errMsg = (Exception)lua["errMsg"];
+                Assert.AreEqual(false, err);
+                Assert.AreNotEqual(null, errMsg.InnerException);
+                Assert.AreEqual("exception test", errMsg.InnerException.Message);
+
+                lua.DoString("err2,errMsg2 = pcall(test.exceptionMethod,test)");
+                err = (bool)lua["err2"];
+
+                errMsg = (Exception)lua["errMsg2"];
+                Assert.AreEqual(false, err);
+                Assert.AreNotEqual(null, errMsg.InnerException);
+                Assert.AreEqual("exception test", errMsg.InnerException.Message);
+            }
+        }
+
+        /*
+        * Tests capturing multiple exceptions in LuaFunction call
+        */
+        [Test]
+        public void ThrowMultipleExceptionsInScript()
+        {
+            string script1 =
+                "function run()\n" +
+                "   function callMethod() " +
+                "       test:exceptionMethod() " +
+                "       test:exceptionMethod() " +
+                "   end" +
+                "   err1, errMsg1 = pcall(callMethod);\n" +
+              //  "   err2, errMsg2 = pcall(callMethod);\n" +
+                "end ";
+
+            //string script2 = "   err, errMsg = pcall(test.exceptionMethod,test);\n";
+
+            TestClass test = new TestClass();
+
+            using (Lua lua = new Lua())
+            {
+                lua["test"] = test;
+
+                //lua.DoString(script2);
+
+                //bool err = (bool)lua["err"];
+                //var errMsg = (Exception)lua["errMsg"];
+                //Assert.AreEqual(false, err);
+                //Assert.AreNotEqual(null, errMsg.InnerException);
+                //Assert.AreEqual("exception test", errMsg.InnerException.Message);
+
+                lua.DoString(script1);
+                (lua["run"] as LuaFunction).Call();
+                (lua["run"] as LuaFunction).Call();
+
+                bool err = (bool)lua["err1"];
+                var errMsg = (Exception)lua["errMsg1"];
+                Assert.AreEqual(false, err);
+                Assert.AreNotEqual(null, errMsg.InnerException);
+                Assert.AreEqual("exception test", errMsg.InnerException.Message);
+            }
+        }
+
 
         static Lua m_lua;
     }


### PR DESCRIPTION
* Lua.Error() will call setjmp and this can cause a crash with CLR on Linux, it seems that calling the setjmp longjmp twice will crash on *nix systems.
This should make this issue work a bit better: https://github.com/NLua/NLua/issues/344