### PR TITLE
Fixed  #355 new Guid

### DIFF
--- a/src/CheckType.cs
+++ b/src/CheckType.cs
@@ -148,7 +148,7 @@ namespace NLua
                 if (luatype == LuaType.Function || luatype == LuaType.Nil)
                     return _extractValues[paramType];
             }
-            else if (typeof(Delegate).IsAssignableFrom(paramType) && luatype == LuaType.Function)
+            else if (typeof(Delegate).IsAssignableFrom(paramType) && luatype == LuaType.Function && paramType.GetMethod("Invoke") != null)
                 return new DelegateGenerator(_translator, paramType).ExtractGenerated;
             else if (paramType.IsInterface && luatype == LuaType.Table)
                 return new ClassGenerator(_translator, paramType).ExtractGenerated;

--- a/src/Metatables.cs
+++ b/src/Metatables.cs
@@ -1258,6 +1258,19 @@ namespace NLua
             return instance.CallConstructorInternal(luaState);
         }
 
+        private static ConstructorInfo[] ReorderConstructors(ConstructorInfo[] constructors)
+        {
+            int len = constructors.Length;
+
+            if (len < 2)
+                return constructors;
+
+            return constructors.
+                GroupBy(c => c.GetParameters().Length).
+                SelectMany(g => g.OrderByDescending(ci => ci.ToString())).
+                ToArray();
+        }
+
         private int CallConstructorInternal(LuaState luaState)
         {
             var klass = _translator.GetRawNetObject(luaState, 1) as ProxyType;
@@ -1273,7 +1286,7 @@ namespace NLua
 
             luaState.Remove(1);
             ConstructorInfo[] constructors = klass.UnderlyingSystemType.GetConstructors();
-
+            constructors = ReorderConstructors(constructors);
             foreach (var constructor in constructors)
             {
                 bool isConstructor = MatchParameters(luaState, constructor, validConstructor, 0);

--- a/src/Method/LuaMethodWrapper.cs
+++ b/src/Method/LuaMethodWrapper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
@@ -67,9 +67,23 @@ namespace NLua.Method
             _lastCalledMethod = new MethodCache();
 
             _isStatic = (bindingType & BindingFlags.Static) == BindingFlags.Static;
-            _members = GetMethodsRecursively(targetType.UnderlyingSystemType,
+            MethodInfo [] methods = GetMethodsRecursively(targetType.UnderlyingSystemType,
                 methodName,
                 bindingType | BindingFlags.Public);
+            _members = ReorderMethods(methods);
+        }
+
+        private static MethodInfo[] ReorderMethods(MethodInfo[] m)
+        {
+            int len = m.Length;
+
+            if (len < 2)
+                return m;
+
+            return m.
+                GroupBy(c => c.GetParameters().Length).
+                SelectMany(g => g.OrderByDescending(ci => ci.ToString())).
+                ToArray();
         }
 
         MethodInfo[] GetMethodsRecursively(Type type, string methodName, BindingFlags bindingType)

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -2782,6 +2782,20 @@ namespace NLuaTest
             }
         }
 
+        [Test]
+        public void TestGuid()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua.LoadCLRPackage();
+                object o = lua.DoString(@" import ('mscorlib','System')
+                              return Guid('adc70ae1-769e-4ace-aa83-928a604c5739')
+                              ")[0];
+                
+                Assert.AreEqual(new Guid("adc70ae1-769e-4ace-aa83-928a604c5739"), o);
+            }
+        }
+
 
         static Lua m_lua;
     }


### PR DESCRIPTION
* Guid has a lot of ctor overload, the `byte[]` was being used instead the `string`.
Reorder ctor info before trying to match the parameters.