### PR TITLE
Fix broken logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 >
 > 💕 We also appreaciate any **Sponsor**  [ [Patreon](https://www.patreon.com/codefoco) | [PayPal](https://paypal.me/viniciusjarina) ] 
 
-[![Logo](https://secure.gravatar.com/avatar/77ecf0fb9d8419be7715c6e822e66562?s=150)]()
+[![Logo](https://secure.gravatar.com/avatar/77ecf0fb9d8419be7715c6e822e66562?s=150)](https://github.com/NLua/NLua)
 
 NLua
 =======


### PR DESCRIPTION
Clicking on the logo would 404 at https://github.com/NLua/NLua/blob/master. This makes it redirect to https://github.com/NLua/NLua.