### PR TITLE
Update to example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Retrieving global values:
 
 ```csharp
 	state.DoString ("y = 10 + x*(5 + 2)");
-	double y = (double) state ["y"]; // Retrieve the value of y
+	var y = state ["y"] as double; // Retrieve the value of y
 ```
 
 Retrieving Lua functions:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Retrieving global values:
 
 ```csharp
 	state.DoString ("y = 10 + x*(5 + 2)");
-	var y = state ["y"] as double; // Retrieve the value of y
+	double y = (double) state ["y"]; // Retrieve the value of y
 ```
 
 Retrieving Lua functions:


### PR DESCRIPTION
Example of converting a Lua global to a double should use a cast.