### PR TITLE
Use configurable MaximumRecursion

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -213,6 +213,11 @@ namespace NLua
 //";
         public bool UseTraceback { get; set; } = false;
 
+        /// <summary>
+        /// The maximum number of recursive steps to take when adding global reference variables.  Defaults to 2.
+        /// </summary>
+        public int MaximumRecursion { get; set;} = 2;
+
         #region Globals auto-complete
         /// <summary>
         /// An alphabetically sorted list of all globals (objects, methods, etc.) externally added to this Lua instance
@@ -631,7 +636,7 @@ namespace NLua
                 _globals.Add(path + "(");
             }
             // If the type is a class or an interface and recursion hasn't been running too long, list the members
-            else if ((type.IsClass || type.IsInterface) && type != typeof(string) && recursionCounter < 2)
+            else if ((type.IsClass || type.IsInterface) && type != typeof(string) && recursionCounter < MaximumRecursion)
             {
                 #region Methods
                 foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance))

--- a/tests/build/net45/NLuaTest.csproj
+++ b/tests/build/net45/NLuaTest.csproj
@@ -45,7 +45,6 @@
       <HintPath>..\..\..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />

--- a/tests/build/net45/NLuaTest.csproj
+++ b/tests/build/net45/NLuaTest.csproj
@@ -45,6 +45,7 @@
       <HintPath>..\..\..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -2796,56 +2796,6 @@ namespace NLuaTest
             }
         }
 
-        [TestCase(0)]
-        [TestCase(1)]
-        [TestCase(2)]
-        [TestCase(3)]
-        public void TestMaximumRecursion(int maxRecursion)
-        {
-            var dt = new System.Data.DataTable();
-            dt.Columns.Add("MyCol");
-            Assert.AreEqual("MyCol",dt.Columns[0].ColumnName);
-            Assert.AreEqual("MyCol",dt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName);
-            Assert.AreEqual("MyCol",dt.Columns[0].ColumnName.ToString());
-            Assert.AreEqual("MyCol",dt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName.ToString());
-            
-            using (Lua lua = new Lua())
-            {
-                lua.MaximumRecursion = maxRecursion;
-                lua.LoadCLRPackage();
-                lua["myDt"] = dt;
-                
-                if(maxRecursion == 0)
-                    Assert.AreEqual(1,lua.Globals.Count()); //register only the root reference
-                else
-                    Assert.Greater(lua.Globals.Count(),1); //many globals registered
-
-                object o = lua.DoString(@" import ('mscorlib','System')
-                              import ('System.Data','System.Data')
-                              return myDt.Columns[0].ColumnName
-                              ")[0];
-                
-                Assert.AreEqual("MyCol", o);
-
-
-                o = lua.DoString(@" return myDt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName
-                              ")[0];
-                
-                Assert.AreEqual("MyCol", o);
-
-                o = lua.DoString(@" import ('mscorlib','System')
-                              return myDt.Columns[0]:ToString()
-                              ")[0];
-                
-                Assert.AreEqual("MyCol", o);
-
-
-                o = lua.DoString(@" return myDt.Columns[0].Table.Columns[0].Table.Columns[0]:ToString()
-                              ")[0];
-                
-                Assert.AreEqual("MyCol", o);
-            }
-        }
 
         static Lua m_lua;
     }

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -2796,6 +2796,56 @@ namespace NLuaTest
             }
         }
 
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        public void TestMaximumRecursion(int maxRecursion)
+        {
+            var dt = new System.Data.DataTable();
+            dt.Columns.Add("MyCol");
+            Assert.AreEqual("MyCol",dt.Columns[0].ColumnName);
+            Assert.AreEqual("MyCol",dt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName);
+            Assert.AreEqual("MyCol",dt.Columns[0].ColumnName.ToString());
+            Assert.AreEqual("MyCol",dt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName.ToString());
+            
+            using (Lua lua = new Lua())
+            {
+                lua.MaximumRecursion = maxRecursion;
+                lua.LoadCLRPackage();
+                lua["myDt"] = dt;
+                
+                if(maxRecursion == 0)
+                    Assert.AreEqual(1,lua.Globals.Count()); //register only the root reference
+                else
+                    Assert.Greater(lua.Globals.Count(),1); //many globals registered
+
+                object o = lua.DoString(@" import ('mscorlib','System')
+                              import ('System.Data','System.Data')
+                              return myDt.Columns[0].ColumnName
+                              ")[0];
+                
+                Assert.AreEqual("MyCol", o);
+
+
+                o = lua.DoString(@" return myDt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName
+                              ")[0];
+                
+                Assert.AreEqual("MyCol", o);
+
+                o = lua.DoString(@" import ('mscorlib','System')
+                              return myDt.Columns[0]:ToString()
+                              ")[0];
+                
+                Assert.AreEqual("MyCol", o);
+
+
+                o = lua.DoString(@" return myDt.Columns[0].Table.Columns[0].Table.Columns[0]:ToString()
+                              ")[0];
+                
+                Assert.AreEqual("MyCol", o);
+            }
+        }
 
         static Lua m_lua;
     }

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -2802,48 +2802,23 @@ namespace NLuaTest
         [TestCase(3)]
         public void TestMaximumRecursion(int maxRecursion)
         {
-            var dt = new System.Data.DataTable();
-            dt.Columns.Add("MyCol");
-            Assert.AreEqual("MyCol",dt.Columns[0].ColumnName);
-            Assert.AreEqual("MyCol",dt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName);
-            Assert.AreEqual("MyCol",dt.Columns[0].ColumnName.ToString());
-            Assert.AreEqual("MyCol",dt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName.ToString());
+            var tc = new TestClass();
+            tc.LongValue = 5;
             
             using (Lua lua = new Lua())
             {
                 lua.MaximumRecursion = maxRecursion;
                 lua.LoadCLRPackage();
-                lua["myDt"] = dt;
+                lua["myTc"] = tc;
                 
                 if(maxRecursion == 0)
                     Assert.AreEqual(1,lua.Globals.Count()); //register only the root reference
                 else
-                    Assert.Greater(lua.Globals.Count(),1); //many globals registered
+                    Assert.Greater(lua.Globals.Count(),1); //many globals registered (all sub properties)
 
-                object o = lua.DoString(@" import ('mscorlib','System')
-                              import ('System.Data','System.Data')
-                              return myDt.Columns[0].ColumnName
-                              ")[0];
-                
-                Assert.AreEqual("MyCol", o);
-
-
-                o = lua.DoString(@" return myDt.Columns[0].Table.Columns[0].Table.Columns[0].ColumnName
-                              ")[0];
-                
-                Assert.AreEqual("MyCol", o);
-
-                o = lua.DoString(@" import ('mscorlib','System')
-                              return myDt.Columns[0]:ToString()
-                              ")[0];
-                
-                Assert.AreEqual("MyCol", o);
-
-
-                o = lua.DoString(@" return myDt.Columns[0].Table.Columns[0].Table.Columns[0]:ToString()
-                              ")[0];
-                
-                Assert.AreEqual("MyCol", o);
+                // ensure even with 0 recursion we can still call properties
+                object o = lua.DoString(@"return myTc.LongValue")[0];
+                Assert.AreEqual(5, o);
             }
         }
 

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -2814,7 +2814,7 @@ namespace NLuaTest
                 if(maxRecursion == 0)
                     Assert.AreEqual(1,lua.Globals.Count()); //register only the root reference
                 else
-                    Assert.Greater(lua.Globals.Count(),1); //many globals registered (all sub properties)
+                    Assert.IsTrue(lua.Globals.Count() > 1); //many globals registered (all sub properties)
 
                 // ensure even with 0 recursion we can still call properties
                 object o = lua.DoString(@"return myTc.LongValue")[0];


### PR DESCRIPTION
This PR addresses the issue where you need to give a large object with many child methods as a global variable but want to restrict the amount of up front reflection that happens (for performance).

https://github.com/NLua/NLua/issues/366

I have used System.DataTable in the test since it is a good complex class with self referencing properties.  

Setting `MaximumRecursion` to 0 on an instance of `Lua` results in only a single global being created and no reflection exploration happening (see TestMaximumRecursion).