### PR TITLE
Fix Parameter Matching for String Parameters on Null Caching

### DIFF
--- a/src/CheckType.cs
+++ b/src/CheckType.cs
@@ -128,10 +128,8 @@ namespace NLua
             }
             else if (netParamIsString)
             {
-                if (luaState.IsString(stackPos))
+                if (luaState.IsString(stackPos) || luatype == LuaType.Nil)
                     return _extractValues[paramType];
-                if (luatype == LuaType.Nil)
-                    return _extractNetObject; // kevinh - silently convert nil to a null string pointer
             }
             else if (paramType == typeof(LuaTable))
             {

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -1101,6 +1101,26 @@ namespace NLuaTest
             }
         }
         /*
+        * Tests calling of an object's method with a nil string param value, 
+        * then a non-null string value. This test ensures that after a method 
+        * is cached, a string parameter can be retrieved appropriately.
+        */
+        [Test]
+        public void CallObjectMethodNilStringParam()
+        {
+            using (Lua lua = new Lua())
+            {
+                TestTypes.TestClass t1 = new TestTypes.TestClass();
+                lua["netobj"] = t1;
+                string inputParam = "foo";
+                lua.DoString($"val=netobj:getParamStrVal(nil)");
+                lua.DoString($"val=netobj:getParamStrVal('{inputParam}')");
+                string val = (string)lua.GetString("val");
+
+                Assert.AreEqual(inputParam, val);
+            }
+        }
+        /*
         * Tests calling of an object's method with no overloading
         * and out parameters
         */

--- a/tests/src/TestTypes/TestClass.cs
+++ b/tests/src/TestTypes/TestClass.cs
@@ -115,6 +115,11 @@ namespace NLuaTest.TestTypes
             return strVal;
         }
 
+        public string getParamStrVal(string str)
+        {
+            return str;
+        }
+
         public int outVal(out int val)
         {
             val = 5;


### PR DESCRIPTION
For a function on a net object with string parameters, the 'extractor' for a null string would return an object type.  This extractor is cached, and on the next invocation, a non-null string parameter would try to be extracted as an object type, which would cause a failure.