### PR TITLE
Fix the overloaded methods issue

### DIFF
--- a/src/CheckType.cs
+++ b/src/CheckType.cs
@@ -118,7 +118,7 @@ namespace NLua
 
             if (netParamIsNumeric)
             {
-                if (luaState.IsNumber(stackPos) && !netParamIsString)
+                if (luaState.IsNumericType(stackPos) && !netParamIsString)
                     return _extractValues[paramType];
             }
             else if (paramType == typeof(bool))

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -198,6 +198,13 @@ namespace NLuaTest
                 lua.DoString("i = test:MethodOverload(2,2)\r\nprint(i)");
                 int i = (int) lua.GetNumber("i");
                 Assert.AreEqual(5, i, "#1");
+
+                lua.DoString("v = test:MethodOverload2(11)");
+                var value = lua.GetString("v");
+                Assert.AreEqual("uint32:11", value, "#2");
+                lua.DoString("v = test:MethodOverload2('321')");
+                value = lua.GetString("v");
+                Assert.AreEqual("string:321", value, "#3");
             }
         }
 

--- a/tests/src/TestTypes/TestClass.cs
+++ b/tests/src/TestTypes/TestClass.cs
@@ -296,6 +296,20 @@ namespace NLuaTest.TestTypes
             Console.WriteLine("Overload with out param" + i + ", " + j);
         }
 
+        public string MethodOverload2(uint i)
+        {
+            Console.WriteLine("Overload with uint32 param: " + i );
+
+            return $"uint32:{i}";
+        }
+
+        public string MethodOverload2(string i)
+        {
+            Console.WriteLine("Overload with numeric string param: " + i);
+
+            return $"string:{i}";
+        }
+
         public void Print(object format, params object[] args)
         {
             //just for test,this is not printf implements


### PR DESCRIPTION
The fix addresses the issue of a wrong overloaded method identification where the numeric overload is confused with string one in a case the string represent numeric value, e.g.
void foo(uint32) -> foo(1)
void foo(string) -> foo('1')
Check the the type to be numeric rather than a number: IsNumericType. The side effect of IsNumber check causes numeric strings to be treated as numbers which leads to wrong overloaded method identification.