### PR TITLE
MethodInfo.Invoke on void method crash fix

### DIFF
--- a/NLua.net5.0.sln
+++ b/NLua.net5.0.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NLua", "NLua", "{4A43DAAC-F9FF-4EB1-BFBD-FB4655CCE1F7}"
 EndProject
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\NLua.Shared.projitems*{a1944148-0ad8-4def-a245-60c7a8ae8aa7}*SharedItemsImports = 5
 		src\NLua.Shared.projitems*{bd205ad6-760e-48f3-bab2-21447396bd17}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/GenerateEventAssembly/CodeGeneration.cs
+++ b/src/GenerateEventAssembly/CodeGeneration.cs
@@ -463,9 +463,6 @@ namespace NLua
 
                 generatorBase.Emit(OpCodes.Call, method);
 
-                if (returnType == typeof(void))
-                    generatorBase.Emit(OpCodes.Pop);
-
                 generatorBase.Emit(OpCodes.Ret);
             }
 
@@ -586,14 +583,9 @@ namespace NLua
 
                 generator.Emit(OpCodes.Call, method);
 
-                if (returnType == typeof(void))
-                    generator.Emit(OpCodes.Pop);
-
                 generator.Emit(OpCodes.Ret);
-                generator.Emit(OpCodes.Ldnull);
             }
-            else
-                generator.Emit(OpCodes.Ldnull);
+            generator.Emit(OpCodes.Ldnull);
 
             var lab2 = generator.DefineLabel();
             generator.Emit(OpCodes.Br_S, lab2);


### PR DESCRIPTION
Fixed bug where calling a method returning void through reflection threw an InvalidProgramException.

After calling the base method and/or the overriding method, the generated code would pop, trying to discard the return value, but since void methods don't push a return value onto the stack, the code would pop on the empty stack, causing a crash.