### PR TITLE
only convert IConvertible

### DIFF
--- a/src/Metatables.cs
+++ b/src/Metatables.cs
@@ -1505,8 +1505,14 @@ namespace NLua
                         if (value != null && value is double && IsInteger((double)value))
                             value = Convert.ToInt32((double)value);
                     }
-
-                    paramArray.SetValue(Convert.ChangeType(value, paramArrayType), paramArrayIndex);
+                    if (typeof(IConvertible).IsAssignableFrom(value.GetType()))
+                    {
+                        paramArray.SetValue(Convert.ChangeType(value, paramArrayType), paramArrayIndex);
+                    }
+                    else
+                    {
+                        paramArray.SetValue(value, paramArrayIndex);
+                    }
                     paramArrayIndex++;
                 }
             }


### PR DESCRIPTION
Avoid Convert throwing InvalidCastException if table includes objects of classes that does not implement IConvertible.
