### PR TITLE
Moved Lua _globals to a separate class (this class includes a fix for #468)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ tests/build/xamarinios/result.xml
 tests/build/xamarinios/TEST-Result-Xamarin.iOS.xml
 tests/build/xamarintvos/result.xml
 build/net6.0/obj
+tests/build/net6.0/obj/
+tests/build/net6.0/bin/

--- a/src/LuaGlobals.cs
+++ b/src/LuaGlobals.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace NLua
+{
+    public class LuaGlobalEntry
+    {
+        /// <summary>
+        /// Type at time of registration.
+        /// </summary>
+        public Type Type { get; private set; }
+
+        public string Path { get; private set; }
+
+        /// <summary>
+        /// List of global properties 'owned' by this entry.
+        /// If this entry is removed all these globals should be removed as well.
+        /// </summary>
+        public List<string> linkedGlobals = new List<string>();
+
+        public LuaGlobalEntry(Type type, string path)
+        {
+            Type = type;
+            Path = path;
+        }
+    }
+
+    public class LuaGlobals
+    {
+        private List<string> _globals = new List<string>();
+        private List<LuaGlobalEntry> _knownTypes = new List<LuaGlobalEntry>();
+
+        public bool _globalsSorted = false;
+
+        public int MaximumRecursion { get; set; } = 2;
+
+        public IEnumerable<string> Globals
+        {
+            get
+            {
+                // Only sort list when necessary
+                if (!_globalsSorted)
+                {
+                    _globals.Sort();
+                    _globalsSorted = true;
+                }
+
+                return _globals;
+            }
+        }
+
+        public bool Contains(string fullPath)
+        {
+            return _globals.Contains(fullPath);
+        }
+
+        public void RemoveGlobal(string path)
+        {
+            var knownType = _knownTypes.FirstOrDefault(x => x.Path.Equals(path));
+            if (knownType != null)
+            {
+                // We need to clean up the globals
+                foreach (var dependent in knownType.linkedGlobals)
+                {
+                    _globals.Remove(dependent);
+                }
+
+                _knownTypes.Remove(knownType);
+            }
+
+            _globals.Remove(path);
+        }
+
+        private LuaGlobalEntry GetKnownType(string path)
+        {
+            return _knownTypes.Find(x => x.Path.Equals(path));
+        }
+
+        public void RegisterGlobal(string path, Type type, int recursionCounter)
+        {
+            var knownType = GetKnownType(path);
+            if (knownType != null)
+            {
+                if (type.Equals(knownType.Type))
+                {
+                    // Object is set to same value so no need to update
+                    return;
+                }
+
+                // Path changed type so we should clean up all known globals associated with the type
+                RemoveGlobal(path);
+            }
+
+            RegisterPath(path, type, recursionCounter);
+
+            // List will need to be sorted on next access
+            _globalsSorted = false;
+        }
+
+        private void RegisterPath(string path, Type type, int recursionCounter, LuaGlobalEntry entry = null)
+        {
+            // If the type is a global method, list it directly
+            if (type == typeof(LuaFunction))
+            {
+                RegisterLuaFunction(path, entry);
+            }
+            // If the type is a class or an interface and recursion hasn't been running too long, list the members
+            else if ((type.IsClass || type.IsInterface) && type != typeof(string) && recursionCounter < MaximumRecursion)
+            {
+                RegisterClassOrInterface(path, type, recursionCounter, entry);
+            }
+            else
+            {
+                RegisterPrimitive(path, entry);
+            }
+        }
+
+        private void RegisterLuaFunction(string path, LuaGlobalEntry entry = null)
+        {
+            // Format for easy method invocation
+            _globals.Add(path + "(");
+
+            if (entry != null)
+            {
+                entry.linkedGlobals.Add(path);
+            }
+        }
+
+        private void RegisterPrimitive(string path, LuaGlobalEntry entry = null)
+        {
+            _globals.Add(path);
+            if (entry != null)
+            {
+                entry.linkedGlobals.Add(path);
+            }
+        }
+
+        private void RegisterClassOrInterface(string path, Type type, int recursionCounter, LuaGlobalEntry entry = null)
+        {
+            if (entry == null)
+            {
+                entry = new LuaGlobalEntry(type, path);
+                _knownTypes.Add(entry);
+            }
+
+            #region Methods
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+            {
+                string name = method.Name;
+                if (
+                    // Check that the LuaHideAttribute and LuaGlobalAttribute were not applied
+                    (!method.GetCustomAttributes(typeof(LuaHideAttribute), false).Any()) &&
+                    (!method.GetCustomAttributes(typeof(LuaGlobalAttribute), false).Any()) &&
+                    // Exclude some generic .NET methods that wouldn't be very usefull in Lua
+                    name != "GetType" && name != "GetHashCode" && name != "Equals" &&
+                    name != "ToString" && name != "Clone" && name != "Dispose" &&
+                    name != "GetEnumerator" && name != "CopyTo" &&
+                    !name.StartsWith("get_", StringComparison.Ordinal) &&
+                    !name.StartsWith("set_", StringComparison.Ordinal) &&
+                    !name.StartsWith("add_", StringComparison.Ordinal) &&
+                    !name.StartsWith("remove_", StringComparison.Ordinal))
+                {
+                    // Format for easy method invocation
+                    string command = path + ":" + name + "(";
+
+                    if (method.GetParameters().Length == 0)
+                        command += ")";
+
+                    _globals.Add(command);
+                    entry.linkedGlobals.Add(command);
+                }
+            }
+            #endregion
+
+            #region Fields
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (
+                    // Check that the LuaHideAttribute and LuaGlobalAttribute were not applied
+                    (!field.GetCustomAttributes(typeof(LuaHideAttribute), false).Any()) &&
+                    (!field.GetCustomAttributes(typeof(LuaGlobalAttribute), false).Any()))
+                {
+                    // Go into recursion for members
+                    RegisterPath(path + "." + field.Name, field.FieldType, recursionCounter + 1, entry);
+                }
+            }
+            #endregion
+
+            #region Properties
+            foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (
+                    // Check that the LuaHideAttribute and LuaGlobalAttribute were not applied
+                    (!property.GetCustomAttributes(typeof(LuaHideAttribute), false).Any()) &&
+                    (!property.GetCustomAttributes(typeof(LuaGlobalAttribute), false).Any())
+                    // Exclude some generic .NET properties that wouldn't be very useful in Lua
+                    && property.Name != "Item")
+                {
+                    // Go into recursion for members
+                    RegisterPath(path + "." + property.Name, property.PropertyType, recursionCounter + 1, entry);
+                }
+            }
+            #endregion
+        }
+    }
+}
+

--- a/src/LuaGlobals.cs
+++ b/src/LuaGlobals.cs
@@ -58,7 +58,7 @@ namespace NLua
 
         public void RemoveGlobal(string path)
         {
-            var knownType = _knownTypes.FirstOrDefault(x => x.Path.Equals(path));
+            var knownType = GetKnownType(path);
             if (knownType != null)
             {
                 // We need to clean up the globals
@@ -69,8 +69,6 @@ namespace NLua
 
                 _knownTypes.Remove(knownType);
             }
-
-            _globals.Remove(path);
         }
 
         private LuaGlobalEntry GetKnownType(string path)

--- a/src/NLua.Shared.projitems
+++ b/src/NLua.Shared.projitems
@@ -26,6 +26,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)LuaBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaFunction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaGlobalAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LuaGlobals.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaHideAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaRegistrationHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaThread.cs" />

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using System.Reflection;
 using System.Threading;
@@ -980,6 +980,71 @@ namespace NLuaTest
                 var t2 = (TestTypes.TestClass)lua["netobj"];
                 Assert.AreEqual(t2.testval, 4);
                 Assert.AreEqual(t1, t2);
+            }
+        }
+        ///*
+        // * Tests setting of a global variable to a CLR object and checking if the Globals correctly registered everything.
+        // */
+        [Test]
+        public void SetGlobalObjectLuaGlobalsListIsCorrect()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua["netobj"] = new TestTypes.GlobalsTestClass();
+
+                var globals = lua.Globals.ToList();
+                Assert.AreEqual(globals.Count, 4);
+                Assert.Contains("netobj.Property1", globals);
+                Assert.Contains("netobj.Property2", globals);
+                Assert.Contains("netobj:Method1()", globals);
+                Assert.Contains("netobj:Method3(", globals);
+            }
+        }
+        ///*
+        // * Tests setting of a global variable to a CLR object value and then re assigning it to a non CLR object.
+        // */
+        [Test]
+        public void SetGlobalObjectAndReasignToNonCLR()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua["netobj"] = new TestTypes.GlobalsTestClass();
+                lua["netobj"] = 4;
+                var globals = lua.Globals.Where(x => x.StartsWith("netobj")).ToList();
+                Assert.AreEqual(1, globals.Count);
+                Assert.Contains("netobj", globals);
+            }
+        }
+        ///*
+        // * Tests setting of a global variable to a CLR object value and then re assigning it to a null value.
+        // */
+        [Test]
+        public void SetGlobalObjectAndReasignToNull()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua["netobj"] = new TestTypes.GlobalsTestClass();
+                lua["netobj"] = null;
+                var globals = lua.Globals.Where(x => x.StartsWith("netobj")).ToList();
+                Assert.AreEqual(0, globals.Count);
+            }
+        }
+        ///*
+        // * Tests setting of a global variable to a CLR object value and then re assigning it to another CLR object of another type.
+        // */
+        [Test]
+        public void SetGlobalObjectAndReasignToOtherCLR()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua["netobj"] = new TestTypes.TestClass();
+                lua["netobj"] = new TestTypes.GlobalsTestClass();
+                var globals = lua.Globals.Where(x => x.StartsWith("netobj")).ToList();
+                Assert.AreEqual(4, globals.Count);
+                Assert.Contains("netobj.Property1", globals);
+                Assert.Contains("netobj.Property2", globals);
+                Assert.Contains("netobj:Method1()", globals);
+                Assert.Contains("netobj:Method3(", globals);
             }
         }
         ///*

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -994,10 +994,10 @@ namespace NLuaTest
 
                 var globals = lua.Globals.ToList();
                 Assert.AreEqual(globals.Count, 4);
-                Assert.Contains("netobj.Property1", globals);
-                Assert.Contains("netobj.Property2", globals);
-                Assert.Contains("netobj:Method1()", globals);
-                Assert.Contains("netobj:Method3(", globals);
+                Assert.True(globals.Contains("netobj.Property1"));
+                Assert.True(globals.Contains("netobj.Property2"));
+                Assert.True(globals.Contains("netobj:Method1()"));
+                Assert.True(globals.Contains("netobj:Method3("));
             }
         }
         ///*
@@ -1012,7 +1012,7 @@ namespace NLuaTest
                 lua["netobj"] = 4;
                 var globals = lua.Globals.Where(x => x.StartsWith("netobj")).ToList();
                 Assert.AreEqual(1, globals.Count);
-                Assert.Contains("netobj", globals);
+                Assert.True(globals.Contains("netobj"));
             }
         }
         ///*
@@ -1041,10 +1041,10 @@ namespace NLuaTest
                 lua["netobj"] = new TestTypes.GlobalsTestClass();
                 var globals = lua.Globals.Where(x => x.StartsWith("netobj")).ToList();
                 Assert.AreEqual(4, globals.Count);
-                Assert.Contains("netobj.Property1", globals);
-                Assert.Contains("netobj.Property2", globals);
-                Assert.Contains("netobj:Method1()", globals);
-                Assert.Contains("netobj:Method3(", globals);
+                Assert.True(globals.Contains("netobj.Property1"));
+                Assert.True(globals.Contains("netobj.Property2"));
+                Assert.True(globals.Contains("netobj:Method1()"));
+                Assert.True(globals.Contains("netobj:Method3("));
             }
         }
         ///*

--- a/tests/src/NLuaTest.Shared.projitems
+++ b/tests/src/NLuaTest.Shared.projitems
@@ -50,5 +50,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestTypes\Vector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestTypes\VectorExtension.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestTypes\GlobalsTestClass.cs" />
   </ItemGroup>
 </Project>

--- a/tests/src/TestTypes/GlobalsTestClass.cs
+++ b/tests/src/TestTypes/GlobalsTestClass.cs
@@ -1,0 +1,24 @@
+namespace NLuaTest.TestTypes
+{
+    class GlobalsTestClass
+    {
+        public int Property1 { get; set; }
+
+        public int Property2{ get; }
+
+        public int Method1()
+        {
+            return 1;
+        }
+
+        private int Method2()
+        {
+            return 2;
+        }
+
+        public int Method3(int param)
+        {
+            return param;
+        }
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/NLua/NLua/issues/468

Basically the following code will lead to a massive slowdown in performance:

```
Lua lua = new Lua();
for (int i = 0; i < 1_000_000; i++)
{
    lua["obj"] = new SomeObject(); // <-- This seems to slow things down
    // lua.DoString("return 2 * obj:SomeMethod()"); // <-- commented to show you don't even need to run a Lua script to trigger the slowdown.

    if (i % 1000 == 0)
    {
        Console.WriteLine($"{1_000_000 - i} remaining");
    }
}

class SomeObject
{
    public int SomeMethod()
    {
        return 2;
    }
}
```

This happens because the `_globals` in the `Lua` class do not get properly cleaned up if you overwrite a C# object. In this case the same globals are added on top of the already existing globals leading to a list of `_globals` with thousands of elements.

This issue https://github.com/NLua/NLua/issues/445 gave me a hint of where to start. However, the solution there will not work since now if you update a path with a value of a different type this is not reflected in `_globals`.

This solution moves the `_globals` object in the `Lua` class to a new `LuaGlobals` class. This class internally keeps track of which C# classes are already registered and what global registration (for methods, property and fields) have been made. 

Then when another registration for the same path but a different type is made, we can easily and quickly clean up all related globals.

As a test try the following code and check the result of the `Globals` object on the `Lua` class:

```
var lua = new Lua();

lua["obj"] = new MyObject();
// At this point Globals will contain two elements -> "obj:SomeMethod()" and "obj:SomeOtherMethod()"
lua["obj"] = 1
// At this point Globals will contain one element -> "obj"

class MyObject
{
    public void SomeMethod()
    {
    }

    public void SomeOtherMethod()
    {
    }
}
```