### PR TITLE
Changed the handling of variadic arguments.

### DIFF
--- a/src/Method/LuaMethodWrapper.cs
+++ b/src/Method/LuaMethodWrapper.cs
@@ -122,15 +122,15 @@ namespace NLua.Method
                 if (_lastCalledMethod.argTypes[i].IsParamsArray)
                 {
                     int count = _lastCalledMethod.argTypes.Length - i;
-                    Array paramArray = _translator.TableToArray(luaState, type.ExtractValue, type.ParameterType, index, count);
+                    Array paramArray = _translator.CreateParamsArray(luaState, type.ExtractValue, type.ParameterType, index, count);
                     args[_lastCalledMethod.argTypes[i].Index] = paramArray;
                 }
                 else
                 {
                     args[type.Index] = type.ExtractValue(luaState, index);
-                }
+            }
 
-                if (_lastCalledMethod.args[_lastCalledMethod.argTypes[i].Index] == null &&
+            if (_lastCalledMethod.args[_lastCalledMethod.argTypes[i].Index] == null &&
                     !luaState.IsNil(i + 1 + numStackToSkip))
                     throw new LuaException(string.Format("Argument number {0} is invalid", (i + 1)));
             }

--- a/src/ObjectTranslator.cs
+++ b/src/ObjectTranslator.cs
@@ -1085,9 +1085,9 @@ namespace NLua
             return metaFunctions.MatchParameters(luaState, method, methodCache, skipParam);
         }
 
-        internal Array TableToArray(LuaState luaState, ExtractValue extractValue, Type paramArrayType, int startIndex, int count)
+        internal Array CreateParamsArray(LuaState luaState, ExtractValue extractValue, Type paramArrayType, int startIndex, int count)
         {
-            return metaFunctions.TableToArray(luaState, extractValue, paramArrayType, ref startIndex, count);
+            return MetaFunctions.CreateParamsArray(luaState, extractValue, paramArrayType, startIndex, count);
         }
 
         private Type TypeOf(LuaState luaState, int idx)

--- a/tests/src/TestTypes/TestClass.cs
+++ b/tests/src/TestTypes/TestClass.cs
@@ -146,6 +146,14 @@ namespace NLuaTest.TestTypes
             return arg;
         }
 
+        /*
+         * Returns the number of arguments received.
+         */
+        public int vararg(params object[] args)
+        {
+            return args.Length;
+        }
+
         public int callDelegate1(TestDelegate1 del)
         {
             return del(2, 3);


### PR DESCRIPTION
### Before:
When a Lua table was provided as an argument to a params array parameter, all values were extracted and added to an array of the expected type. Example:
`func(true, false)`
`func{true, false} -- a table!`
Both invocations were translated to the same number of arguments.
This lead to errors when providing further arguments (besides the initial table). See #463, #466

### After:
Tables are handled like any other type. The code for unpacking a Lua table has been removed from _Metatables.TableToArray_. This method was and **is** responsible for extracting all Lua provided arguments, converting them to C# types and add them to an array (the argument for the params-array-parameter). As the 'unpacking of tables'-part is now gone, it was renamed to 'CreateParamsArray' to better reflect what it actually does. A corresponding wrapper function at _ObjectTranslator_ was renamed as well.

### Impact:
- The changed method is only responsible for applying Lua arguments to an already selected .net method, e.g. It doesn't change the selection of the proper method.
- The changed method is only responsible for handling params-array-parameter, e.g. all non-vararg-methods are unaffected. 
- Implementations which rely on this behavior might break.

