### PR TITLE
Added support for multiple return values via ValueTuple

### DIFF
--- a/src/ObjectTranslator.cs
+++ b/src/ObjectTranslator.cs
@@ -16,6 +16,7 @@ using NLua.Extensions;
 
 using LuaState = KeraLua.Lua;
 using LuaNativeFunction = KeraLua.LuaFunction;
+using System.Runtime.CompilerServices;
 
 namespace NLua
 {
@@ -1074,6 +1075,27 @@ namespace NLua
                 userData.Push(luaState);
             else
                 PushObject(luaState, o, "luaNet_metatable");
+        }
+
+        /*
+         * If the given object is an ITuple value type (e.g. ValueTuple) all elements
+         * of it are pushed onto the stack. Otherwise the element is pushed as is,
+         * according to it's type.
+         */
+        public int PushMultiple(LuaState luaState, object o)
+        {
+            if (o is ITuple tuple && o.GetType().IsValueType)
+            {
+                for (int i = 0; i < tuple.Length; ++i)
+                {
+                    Push(luaState, tuple[i]);
+                }
+
+                return tuple.Length;
+            }
+
+            Push(luaState, o);
+            return 1;
         }
 
         /*

--- a/src/ObjectTranslator.cs
+++ b/src/ObjectTranslator.cs
@@ -1084,6 +1084,7 @@ namespace NLua
          */
         public int PushMultiple(LuaState luaState, object o)
         {
+#if NETCOREAPP1_1_OR_GREATER
             if (o is ITuple tuple && o.GetType().IsValueType)
             {
                 for (int i = 0; i < tuple.Length; ++i)
@@ -1093,7 +1094,7 @@ namespace NLua
 
                 return tuple.Length;
             }
-
+#endif
             Push(luaState, o);
             return 1;
         }

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -1245,6 +1245,37 @@ namespace NLuaTest
             }
         }
         /*
+        * Tests calling of an object's method with multiple return values (Tuple).
+        */
+        [Test]
+        public void CallObjectMethodWithMultipleReturnValues()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua["netobj"] = new TestTypes.TestClass();
+                var ret = lua.DoString("return netobj:returnPair()");
+                Assert.AreEqual(2, ret.Length);
+                Assert.AreEqual(5, ret[0]);
+                Assert.AreEqual("five", ret[1]);
+            }
+        }
+        /*
+        * Tests calling of an object's method with multiple return values (Tuple) and out parameter.
+        */
+        [Test]
+        public void CallObjectMethodWithMultipleReturnValuesAndOutParam()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua["netobj"] = new TestTypes.TestClass();
+                var ret = lua.DoString("return netobj:returnPairWithOutParam()");
+                Assert.AreEqual(3, ret.Length);
+                Assert.AreEqual(5, ret[0]);
+                Assert.AreEqual("five", ret[1]);
+                Assert.AreEqual(true, ret[2]);
+            }
+        }
+        /*
         * Tests calling of an object's method with ref params
         */
         [Test]

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -1244,6 +1244,7 @@ namespace NLuaTest
                 Assert.AreEqual(5, b);
             }
         }
+#if NETCOREAPP1_1_OR_GREATER
         /*
         * Tests calling of an object's method with multiple return values (Tuple).
         */
@@ -1275,6 +1276,7 @@ namespace NLuaTest
                 Assert.AreEqual(true, ret[2]);
             }
         }
+#endif
         /*
         * Tests calling of an object's method with ref params
         */

--- a/tests/src/TestTypes/TestClass.cs
+++ b/tests/src/TestTypes/TestClass.cs
@@ -146,6 +146,7 @@ namespace NLuaTest.TestTypes
             return arg;
         }
 
+#if NETCOREAPP1_1_OR_GREATER
         public (int, string) returnPair()
         {
             return (5, "five");
@@ -156,6 +157,7 @@ namespace NLuaTest.TestTypes
             b = true;
             return (5, "five");
         }
+#endif
 
         /*
          * Returns the number of arguments received.

--- a/tests/src/TestTypes/TestClass.cs
+++ b/tests/src/TestTypes/TestClass.cs
@@ -146,6 +146,17 @@ namespace NLuaTest.TestTypes
             return arg;
         }
 
+        public (int, string) returnPair()
+        {
+            return (5, "five");
+        }
+
+        public (int, string) returnPairWithOutParam(out bool b)
+        {
+            b = true;
+            return (5, "five");
+        }
+
         /*
          * Returns the number of arguments received.
          */


### PR DESCRIPTION
### Before:
Additional return values were supported by means of out/ ref paramters only.

### After:
A returned _ValueTuple_ (all _ITuple_ implementing value types, actually) gets special treatment by returning all elements of the tuple instead of the tuple itself. The returned values preceed all ref/ out parameters.

### Impact:
The old way of returning multiple values is still supported.
Implementations which expect ValueTuples to be returned as a single object might break.
Would fix: #458