### PR TITLE
Registering functions now only register 1 global, fix #480

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -652,7 +652,7 @@ namespace NLua
             }
             set
             {
-                if (value != null && value.GetType().IsAssignableTo(typeof(MethodBase)))
+                if (value != null && value.GetType().IsSubclassOf(typeof(MethodBase)))
                 {
                     // If the value is a delegate type, instead treat it as a function
                     this.RegisterFunction(fullPath, (MethodBase)value);

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -652,7 +652,7 @@ namespace NLua
             }
             set
             {
-                if (value is not null && value.GetType().IsAssignableTo(typeof(MethodBase)))
+                if (value != null && value.GetType().IsAssignableTo(typeof(MethodBase)))
                 {
                     // If the value is a delegate type, instead treat it as a function
                     this.RegisterFunction(fullPath, (MethodBase)value);

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -652,7 +652,16 @@ namespace NLua
             }
             set
             {
-               SetObjectToPath(fullPath, value);
+                if (value is not null && value.GetType().IsAssignableTo(typeof(MethodBase)))
+                {
+                    // If the value is a delegate type, instead treat it as a function
+                    this.RegisterFunction(fullPath, (MethodBase)value);
+                }
+                else
+                {
+                    // Otherwise, treat it as normal
+                    SetObjectToPath(fullPath, value);
+                }
             }
         }
 

--- a/src/LuaGlobals.cs
+++ b/src/LuaGlobals.cs
@@ -100,7 +100,7 @@ namespace NLua
         private void RegisterPath(string path, Type type, int recursionCounter, LuaGlobalEntry entry = null)
         {
             // If the type is a global method, list it directly
-            if (type == typeof(LuaFunction))
+            if (type == typeof(KeraLua.LuaFunction))
             {
                 RegisterLuaFunction(path, entry);
             }

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -3167,7 +3167,6 @@ namespace NLuaTest
             }
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         /*
             * Tests registering a global function with RegisterFunction and with the indexer
             * Makes sure that the amount of registered globals is correct
@@ -3184,7 +3183,6 @@ namespace NLuaTest
                 Assert.AreEqual(2, lua.Globals.Count());
             }
         }
-#endif
 
         [Test]
         public void TestGuid()

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -3226,7 +3226,18 @@ namespace NLuaTest
             }
         }
 
+        [Test]
+        public void TestAmountOfRegisteredGlobals()
+        {
+            using (Lua lua = new Lua())
+            {
+                var testFunc = (string s) => s;
+                lua.RegisterFunction("testFunc1", null, testFunc.Method);
+                lua["testFunc2"] = testFunc.Method;
 
+                Assert.AreEqual(2, lua.Globals.Count());
+            }
+        }
 
         static Lua m_lua;
     }

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -3167,6 +3167,25 @@ namespace NLuaTest
             }
         }
 
+#if NETCOREAPP3_1_OR_GREATER
+        /*
+            * Tests registering a global function with RegisterFunction and with the indexer
+            * Makes sure that the amount of registered globals is correct
+        */
+        [Test]
+        public void TestAmountOfRegisteredGlobals()
+        {
+            using (Lua lua = new Lua())
+            {
+                Func<string, string> testFunc = (string s) => s;
+                lua.RegisterFunction("testFunc1", null, testFunc.Method);
+                lua["testFunc2"] = testFunc.Method;
+
+                Assert.AreEqual(2, lua.Globals.Count());
+            }
+        }
+#endif
+
         [Test]
         public void TestGuid()
         {
@@ -3223,19 +3242,6 @@ namespace NLuaTest
                 Assert.AreEqual("Gamma", lua.DoString("return mc.teststrval")[0]);
                 Assert.AreEqual(3, lua.DoString("return mc[1]")[0]);
                 Assert.AreEqual(1, lua.DoString("return mc['fff']")[0]);
-            }
-        }
-
-        [Test]
-        public void TestAmountOfRegisteredGlobals()
-        {
-            using (Lua lua = new Lua())
-            {
-                Func<string, string> testFunc = (string s) => s;
-                lua.RegisterFunction("testFunc1", null, testFunc.Method);
-                lua["testFunc2"] = testFunc.Method;
-
-                Assert.AreEqual(2, lua.Globals.Count());
             }
         }
 

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -3231,7 +3231,7 @@ namespace NLuaTest
         {
             using (Lua lua = new Lua())
             {
-                var testFunc = (string s) => s;
+                Func<string, string> testFunc = (string s) => s;
                 lua.RegisterFunction("testFunc1", null, testFunc.Method);
                 lua["testFunc2"] = testFunc.Method;
 


### PR DESCRIPTION
This PR fixes #480 that I posted earlier, by applying the suggested changes. In addition to the suggested changes, for the following to work, some more work had to be done to the indexer for `Lua`.

```c#
lua["testFunc"] = testFunc.Method;
```

It first checks to see if the value that is being assigned is assignable to the `MethodBase` type, and if it is, then it will handle it as registering a function instead.

@viniciusjarina Any thoughts on the changes?