### PR TITLE
(fix) SetDebugHook returns -1 anyway

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -944,6 +944,7 @@ namespace NLua
             {
                 _hookCallback = DebugHookCallback;
                 _luaState.SetHook(_hookCallback, mask, count);
+                retutn 0;
             }
 
             return -1;


### PR DESCRIPTION
SetDebugHook should returns -1 only if hook is already set. but currently it returns -1 anyway.