### PR TITLE
(fix) SetDebugHook returns -1 anyway

### DIFF
--- a/build/targets/NLua.Sign.targets
+++ b/build/targets/NLua.Sign.targets
@@ -7,6 +7,5 @@
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\..\..\$(KeyFileName)</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <Target Name="_SignAssembly" AfterTargets="CoreCompile" Condition="'$(SignAssembly)' == 'true' and '$(OS)' !='Windows_NT' ">
-        <Exec Command="sn -q -R @(IntermediateAssembly -> '&quot;%(Identity)&quot;') &quot;$(AssemblyOriginatorKeyFile)&quot;" />
     </Target>
 </Project>

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -944,6 +944,7 @@ namespace NLua
             {
                 _hookCallback = DebugHookCallback;
                 _luaState.SetHook(_hookCallback, mask, count);
+                retutn 0;
             }
 
             return -1;

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -275,6 +275,15 @@ namespace NLua
             }
         }
 
+        public Lua(LuaAlloc alloc, IntPtr ptr , bool openLibs = true)
+        {
+            _luaState = new LuaState(alloc, ptr);
+            if (openLibs)  _luaState.OpenLibs();
+            Init();
+            // We need to keep this in a managed reference so the delegate doesn't get garbage collected
+            _luaState.AtPanic(PanicCallback);
+        }
+
         public Lua(bool openLibs = true)
         {
             _luaState = new LuaState(openLibs);

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -944,7 +944,7 @@ namespace NLua
             {
                 _hookCallback = DebugHookCallback;
                 _luaState.SetHook(_hookCallback, mask, count);
-                retutn 0;
+                return 0;
             }
 
             return -1;


### PR DESCRIPTION
SetDebugHook should return -1 if hook is already set, but currently it returns -1 anyway.

let's return 0 for successful set .