### PR TITLE
Set debug hook fix

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -944,6 +944,7 @@ namespace NLua
             {
                 _hookCallback = DebugHookCallback;
                 _luaState.SetHook(_hookCallback, mask, count);
+                retutn 0;
             }
 
             return -1;

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -944,7 +944,7 @@ namespace NLua
             {
                 _hookCallback = DebugHookCallback;
                 _luaState.SetHook(_hookCallback, mask, count);
-                retutn 0;
+                return 0;
             }
 
             return -1;


### PR DESCRIPTION
Set debug hook should return -1 only if hook is already set. but it is currently returning -1 anyway.
let's return 0 for a successful set.