### PR TITLE
Added support for generic class parameters for generic methods

### DIFF
--- a/src/CheckType.cs
+++ b/src/CheckType.cs
@@ -117,6 +117,14 @@ namespace NLua
                 if (luatype == LuaType.Number)
                     return _extractValues[typeof(double)];
             }
+
+            //Added support for generic type
+            if (paramType.IsGenericType)
+            {
+                if (luatype == LuaType.UserData)
+                    return _extractValues[typeof(object)];
+            }
+
             bool netParamIsString = paramType == typeof(string) || paramType == typeof(char[]) || paramType == typeof(byte[]);
 
             if (netParamIsNumeric)

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -492,6 +492,22 @@ namespace NLuaTest
 
                 Assert.AreEqual(true, classWithGenericMethod.GenericMethodSuccess);
                 Assert.AreEqual(56, (classWithGenericMethod.PassedValue as TestTypes.TestClass).val);
+
+
+                lua.RegisterFunction("genericMethod3", classWithGenericMethod, typeof(TestClassWithGenericMethod).GetMethod("GenericMethodWithGenericTypes"));
+
+                try
+                {
+                    lua["ts"] = new string[] { "aaa", "bbb", "ccc" };
+                    lua["dic"] = new Dictionary<string, int> { { "ddd", 111 }, { "eee", 222 }, { "fff", 333 } };
+                    lua.DoString("genericMethod3(ts, dic)");
+                }
+                catch
+                {
+                }
+
+                Assert.AreEqual(true, classWithGenericMethod.GenericMethodSuccess);
+                Assert.AreEqual(true, classWithGenericMethod.Validate<int>(6));
             }
         }
 

--- a/tests/src/TestTypes/TestClassWithGenericMethod.cs
+++ b/tests/src/TestTypes/TestClassWithGenericMethod.cs
@@ -1,4 +1,7 @@
-﻿namespace NLuaTest.TestTypes
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace NLuaTest.TestTypes
 {
     /// <summary>
     /// Normal class containing a generic method
@@ -32,6 +35,12 @@
             _PassedValue = value;
             this.x = x;
             this.y = y;
+            _GenericMethodSuccess = true;
+        }
+
+        public void GenericMethodWithGenericTypes<T, T1>(IEnumerable<T> ts, Dictionary<T, T1> dic)
+        {
+            _PassedValue = dic.Count() + ts.Count();
             _GenericMethodSuccess = true;
         }
 


### PR DESCRIPTION
Added support for generic class parameters for generic methods, and now Linq methods, IEnumerable, Dictionary, and more can be used.