### PR TITLE
Fix finalizability of Lua instances

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -1056,8 +1056,7 @@ namespace NLua
             var debug = LuaDebug.FromIntPtr(luaDebug);
 
             ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(state);
-            Lua lua = translator.Interpreter;
-            lua.DebugHookCallbackInternal(debug);
+            translator.Interpreter?.DebugHookCallbackInternal(debug);
         }
 
         private void DebugHookCallbackInternal(LuaDebug luaDebug)

--- a/src/LuaBase.cs
+++ b/src/LuaBase.cs
@@ -13,7 +13,7 @@ namespace NLua
 
         protected bool TryGet(out Lua lua)
         {
-            if (_lua.State == null)
+            if (_lua?.State == null)
             {
                 lua = null;
                 return false;

--- a/src/Metatables.cs
+++ b/src/Metatables.cs
@@ -1350,9 +1350,10 @@ namespace NLua
                 catch (TargetInvocationException e)
                 {
                     // Failure of method invocation
-                    if (_translator.interpreter.UseTraceback)
-                        e.GetBaseException().Data["Traceback"] = _translator.interpreter.GetDebugTraceback();
-                    return  _translator.Interpreter.SetPendingException(e.GetBaseException());
+                    Lua interpreter = _translator.Interpreter;
+                    if (interpreter?.UseTraceback is true)
+                        e.GetBaseException().Data["Traceback"] = interpreter.GetDebugTraceback();
+                    return interpreter?.SetPendingException(e.GetBaseException()) ?? 0;
                 }
                 catch (Exception e)
                 {

--- a/src/Method/LuaMethodWrapper.cs
+++ b/src/Method/LuaMethodWrapper.cs
@@ -104,7 +104,7 @@ namespace NLua.Method
         /// <param name="e">null for no pending exception</param>
         int SetPendingException(Exception e)
         {
-            return _translator.interpreter.SetPendingException(e);
+            return _translator.Interpreter?.SetPendingException(e) ?? 0;
         }
 
         void FillMethodArguments(LuaState luaState, int numStackToSkip)
@@ -175,8 +175,9 @@ namespace NLua.Method
             catch (TargetInvocationException e)
             {
                 // Failure of method invocation
-                if (_translator.interpreter.UseTraceback) 
-                    e.GetBaseException().Data["Traceback"] = _translator.interpreter.GetDebugTraceback();
+                Lua interpreter = _translator.Interpreter;
+                if (interpreter?.UseTraceback is true) 
+                    e.GetBaseException().Data["Traceback"] = interpreter.GetDebugTraceback();
                 return SetPendingException(e.GetBaseException());
             }
             catch (Exception e)

--- a/src/ObjectTranslatorPool.cs
+++ b/src/ObjectTranslatorPool.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using NLua.Exceptions;
 using LuaState = KeraLua.Lua;
 
@@ -10,14 +9,14 @@ namespace NLua
     {
         private static volatile ObjectTranslatorPool _instance = new ObjectTranslatorPool();
 
-        private ConditionalWeakTable<LuaState, ObjectTranslator> translators = new ConditionalWeakTable<LuaState, ObjectTranslator>();
+        private ConcurrentDictionary<LuaState, ObjectTranslator> translators = new ConcurrentDictionary<LuaState, ObjectTranslator>();
 
         public static ObjectTranslatorPool Instance => _instance;
 
 
         public void Add(LuaState luaState, ObjectTranslator translator)
         {
-            if(!translators.TryAdd(luaState, translator))
+            if (!translators.TryAdd(luaState, translator))
                 throw new ArgumentException("An item with the same key has already been added. ", "luaState");
         }
 
@@ -25,7 +24,7 @@ namespace NLua
         {
             ObjectTranslator translator;
 
-            if(!translators.TryGetValue(luaState, out translator))
+            if (!translators.TryGetValue(luaState, out translator))
             {
                 LuaState main = luaState.MainThread;
 
@@ -37,8 +36,8 @@ namespace NLua
 
         public void Remove(LuaState luaState)
         {
-            translators.Remove(luaState);
+            ObjectTranslator translator;
+            translators.TryRemove(luaState, out translator);
         }
     }
 }
-

--- a/src/ObjectTranslatorPool.cs
+++ b/src/ObjectTranslatorPool.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using NLua.Exceptions;
 using LuaState = KeraLua.Lua;
 
@@ -9,7 +10,7 @@ namespace NLua
     {
         private static volatile ObjectTranslatorPool _instance = new ObjectTranslatorPool();
 
-        private ConcurrentDictionary<LuaState, ObjectTranslator> translators = new ConcurrentDictionary<LuaState, ObjectTranslator>();
+        private ConditionalWeakTable<LuaState, ObjectTranslator> translators = new ConditionalWeakTable<LuaState, ObjectTranslator>();
 
         public static ObjectTranslatorPool Instance => _instance;
 
@@ -36,8 +37,7 @@ namespace NLua
 
         public void Remove(LuaState luaState)
         {
-            ObjectTranslator translator;
-            translators.TryRemove(luaState, out translator);
+            translators.Remove(luaState);
         }
     }
 }

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -228,6 +228,7 @@ namespace NLuaTest
         }
 
         [Test]
+        [Platform(Exclude = "mono", Reason = "The test requires a precise GC.")]
         public void TestFinalize()
         {
             WeakReference luaRef = CreateWeakReferenceToLuaInstance();

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -230,7 +230,7 @@ namespace NLuaTest
         [Test]
         public void TestFinalize()
         {
-            WeakReference luaRef = CreateInstance();
+            WeakReference luaRef = CreateWeakReferenceToLuaInstance();
             for (int i = 0; i < 3 && luaRef.IsAlive; i++)
             {
                 GC.Collect();
@@ -238,20 +238,20 @@ namespace NLuaTest
             }
 
             Assert.False(luaRef.IsAlive);
+        }
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            WeakReference CreateInstance()
-            {
-                Lua lua = new();
-                _Calc(lua, 42);
-                return new WeakReference(lua);
-            }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private WeakReference CreateWeakReferenceToLuaInstance()
+        {
+            Lua lua = new Lua();
+            _Calc(lua, 42);
+            return new WeakReference(lua);
         }
 
         private void _Calc(Lua lua, int i)
         {
             lua.DoString(
-                        "sqrt = math.sqrt;" +
+                "sqrt = math.sqrt;" +
                 "sqr = function(x) return math.pow(x,2); end;" +
                 "log = math.log;" +
                 "log10 = math.log10;" +

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -17,6 +17,7 @@ using LuaFunction = NLua.LuaFunction;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 // ReSharper disable StringLiteralTypo
 
@@ -224,6 +225,27 @@ namespace NLuaTest
 
             long endMem = System.Diagnostics.Process.GetCurrentProcess().WorkingSet64;
             Console.WriteLine("Was using " + startingMem / 1024 / 1024 + "MB, now using: " + endMem  / 1024 / 1024 + "MB");
+        }
+
+        [Test]
+        public void TestFinalize()
+        {
+            WeakReference luaRef = CreateInstance();
+            for (int i = 0; i < 3 && luaRef.IsAlive; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            Assert.False(luaRef.IsAlive);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            WeakReference CreateInstance()
+            {
+                Lua lua = new();
+                _Calc(lua, 42);
+                return new WeakReference(lua);
+            }
         }
 
         private void _Calc(Lua lua, int i)


### PR DESCRIPTION
Lua instances end up being permanently rooted until Dispose is explicitly called, because the ctor roots the Lua instance into a static singleton of ObjectTranslatorPool. ~~This fixes it by replacing the ConcurrentDictionary with a ConditionalWeakTable, in order to avoid the pool keeping a strong reference to the LuaState / Lua objects.~~ This fixes it by making ObjectTranslator's reference to the associated Lua object a weak reference.