### PR TITLE
Attempt to cache result of `GetExtensionMethods` to avoid excessive memory usage

### DIFF
--- a/src/ObjectTranslator.cs
+++ b/src/ObjectTranslator.cs
@@ -17,6 +17,7 @@ using NLua.Extensions;
 using LuaState = KeraLua.Lua;
 using LuaNativeFunction = KeraLua.LuaFunction;
 using System.Runtime.CompilerServices;
+using TypeExtensions = NLua.Extensions.TypeExtensions;
 
 namespace NLua
 {
@@ -315,8 +316,13 @@ namespace NLua
                         return 1;
                     }
                 }
+
                 if (assembly != null && !assemblies.Contains(assembly))
+                {
+                    // clear cache for this list of assemblies
+                    TypeExtensions.ClearExtensionCache(assemblies);
                     assemblies.Add(assembly);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
RFC.

I'm writing a game engine that uses NLua as a modding backend, and I allow the modder to specify a lua function every tick/update (some source removed for brevity):

```csharp
[DynamicallyAccessedMembers(PublicConstructors | PublicProperties)]
public class LuaComponent : Component
{
    private readonly LuaFunction _update;

    public LuaComponent(Entity parent, string identifier, LuaFunction update) : base(parent)
    {
        this._update = update;
        this.ComponentIdentifier = identifier;
    }
    
    public override void Update(double dt, GameState gameState)
    {
        this._update.Call(dt, gameState, this.Parent, this.State);
    }
}
```

This worked fine until we stress tested it in-engine and found `LuaFunction.Call` was causing horrible memory allocations, up to **85 gigabytes** of memory in the Small Object Heap:

![image](https://github.com/user-attachments/assets/a1564046-b319-4f8b-a1f2-df08cbc87e82)
![image](https://github.com/user-attachments/assets/2c0a0751-caf6-4995-8be7-d73bd501bf3f)

This ends up being traced to this call stack:

```csharp
at RuntimeType+RuntimeTypeCache+MemberInfoCache<__Canon>.PopulateMethods(Filter)
at RuntimeType+RuntimeTypeCache+MemberInfoCache<__Canon>.GetListByName(char*, int, byte*, int, MemberListType, CacheType)
at RuntimeType+RuntimeTypeCache+MemberInfoCache<__Canon>.Populate(String, MemberListType, CacheType)
at Enumerable+<SelectManyIterator>d__236<__Canon,__Canon,__Canon>.MoveNext()
at Enumerable+WhereSelectEnumerableIterator<__Canon,__Canon>.ToArray()
at TypeExtensions.GetExtensionMethods(Type, String, IEnumerable) // !! the problematic part !!
at MetaFunctions.GetMethodFallback(Lua, Type, Object, String)
at MetaFunctions.GetMethod(int)
at Lua.CallFunction(Object, Object[], Type[])
at LuaFunction.Call(Object[])
at LuaComponent.Update(double, GameState) in /home/jvyden/Documents/SpaceThing/SpaceThing/Engine/LuaSupport/LuaComponent.cs:line 24 column 9
```

We do bring in the entire `System.Linq` namespace into the lua context, which means the whole `System` assembly so I can see how this spiraled out of control so quick:

```csharp
this._lua.DoString("import ('SpaceThing', 'SpaceThing.Engine')", "net-imports");
this._lua.DoString("import ('SpaceThing', 'SpaceThing.Engine.LuaSupport')", "net-imports");
this._lua.DoString("import ('SpaceThing', 'SpaceThing.Game.Components')", "net-imports");
this._lua.DoString("import ('System', 'System.Linq')", "net-imports");
this._lua.DoString("import ('System.Numerics.Vectors', 'System.Numerics')", "net-imports");
```

I'm not entirely sure if this is in the correct place, nor if it is necessarily the correct solution. However caching the result of the function in a `Dictionary` in `TypeExtensions` effectively removes the allocations. I've tried to follow existing behavior by clearing the cache when new assemblies are added to the `ObjectTranslator`.