### PR TITLE
Fix: Avoid unhandled exceptions in callbacks

### DIFF
--- a/src/Metatables.cs
+++ b/src/Metatables.cs
@@ -99,7 +99,13 @@ namespace NLua
                 return state.Error();
 
             state.Remove(1);
-            int result = func(luaState);
+            int result;
+            try {
+                result = func(luaState);
+            } catch (LuaException ex) {
+                translator.ThrowError(state, ex);
+                return state.Error();
+            }
             var exception = translator.GetObject(state, -1) as LuaScriptException;
 
             if (exception != null)


### PR DESCRIPTION
Calling a C# method from Lua with incorrect parameters as described in https://github.com/NLua/NLua/issues/544 can cause an unhandled exception. 

The exception is thrown within the callback from Lua, which the application cannot handle. This PR catches exceptions at the callback interface and passes them to the application via NLua's built-in method `ObjectTranslator.ThrowError` so that they can be caught.

This is probably not the cleanest solution. I guess the callback code could be refactored to not use exceptions at all (there are a handful of other places where an exception is thrown when a stack overflow occurs), but I don't understand enough of the code base to make these changes myself. So consider this a hotfix.