### PR TITLE
Fix stack leak in CallFunction, DoString, DoFile when UseTraceback is true

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -510,7 +510,12 @@ namespace NLua
                 if (_luaState.PCall(0, -1, errorFunctionIndex) != LuaStatus.OK)
                     ThrowExceptionFromError(oldTop);
 
-                return _translator.PopValues(_luaState, oldTop);
+                var results = _translator.PopValues(_luaState, oldTop);
+
+                if (UseTraceback)
+                    _luaState.SetTop(oldTop - 1);
+
+                return results;
             }
             finally
             {
@@ -545,7 +550,12 @@ namespace NLua
                 if (_luaState.PCall(0, -1, errorFunctionIndex) != LuaStatus.OK)
                     ThrowExceptionFromError(oldTop);
 
-                return _translator.PopValues(_luaState, oldTop);
+                var results = _translator.PopValues(_luaState, oldTop);
+
+                if (UseTraceback)
+                    _luaState.SetTop(oldTop - 1);
+
+                return results;
             }
             finally
             {
@@ -578,7 +588,12 @@ namespace NLua
                 if (_luaState.PCall(0, -1, errorFunctionIndex) != LuaStatus.OK)
                     ThrowExceptionFromError(oldTop);
 
-                 return _translator.PopValues(_luaState, oldTop);
+                var results = _translator.PopValues(_luaState, oldTop);
+
+                if (UseTraceback)
+                    _luaState.SetTop(oldTop - 1);
+
+                return results;
             }
             finally
             {
@@ -849,10 +864,17 @@ namespace NLua
                 _executing = false;
             }
 
-            if (returnTypes != null)
-                return _translator.PopValues(_luaState, oldTop, returnTypes);
+            object[] results;
 
-            return _translator.PopValues(_luaState, oldTop);
+            if (returnTypes != null)
+                results = _translator.PopValues(_luaState, oldTop, returnTypes);
+            else
+                results = _translator.PopValues(_luaState, oldTop);
+
+            if (UseTraceback)
+                _luaState.SetTop(oldTop - 1);
+
+            return results;
         }
 
         /*

--- a/tests/src/LuaTests.cs
+++ b/tests/src/LuaTests.cs
@@ -3320,6 +3320,79 @@ namespace NLuaTest
             }
         }
 
+        [Test]
+        public void UseTraceback_CallFunction_NoStackLeak()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua.UseTraceback = true;
+                lua.DoString("function test_fn() return 42 end");
+                var fn = lua["test_fn"] as LuaFunction;
+
+                int topBefore = lua.State.GetTop();
+
+                for (int i = 0; i < 10000; i++)
+                    fn.Call();
+
+                int topAfter = lua.State.GetTop();
+                Assert.AreEqual(topBefore, topAfter,
+                    $"Lua stack leaked {topAfter - topBefore} slots over 10000 calls with UseTraceback=true");
+            }
+        }
+
+        [Test]
+        public void UseTraceback_DoString_NoStackLeak()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua.UseTraceback = true;
+
+                int topBefore = lua.State.GetTop();
+
+                for (int i = 0; i < 10000; i++)
+                    lua.DoString("return 42");
+
+                int topAfter = lua.State.GetTop();
+                Assert.AreEqual(topBefore, topAfter,
+                    $"Lua stack leaked {topAfter - topBefore} slots over 10000 DoString calls with UseTraceback=true");
+            }
+        }
+
+        [Test]
+        public void UseTraceback_DoString_ReturnsCorrectValues()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua.UseTraceback = true;
+
+                var results = lua.DoString("return 1, 'hello', true");
+                Assert.AreEqual(3, results.Length, "Should return all 3 values");
+                Assert.AreEqual((long)1, results[0]);
+                Assert.AreEqual("hello", results[1]);
+                Assert.AreEqual(true, results[2]);
+            }
+        }
+
+        [Test]
+        public void UseTraceback_Disabled_NoStackLeak()
+        {
+            using (Lua lua = new Lua())
+            {
+                lua.UseTraceback = false;
+                lua.DoString("function test_fn() return 42 end");
+                var fn = lua["test_fn"] as LuaFunction;
+
+                int topBefore = lua.State.GetTop();
+
+                for (int i = 0; i < 10000; i++)
+                    fn.Call();
+
+                int topAfter = lua.State.GetTop();
+                Assert.AreEqual(topBefore, topAfter,
+                    $"Lua stack leaked {topAfter - topBefore} slots over 10000 calls with UseTraceback=false");
+            }
+        }
+
         static Lua m_lua;
     }
 }


### PR DESCRIPTION
## Problem

When `UseTraceback = true`, each successful call to `CallFunction`, `DoString`, or `DoFile` leaks one Lua stack slot. In long-running applications, this eventually causes:

```
NLua.Exceptions.LuaException: Lua stack overflow
```

## Root Cause

`PushDebugTraceback` pushes `debug.traceback` onto the stack and `oldTop` is incremented to account for it. After a successful `PCall`, the traceback function remains on the stack. `PopValues` uses the incremented `oldTop` to correctly skip the traceback when extracting results, then calls `SetTop(oldTop)` — but since `oldTop` includes the traceback position, one slot is leaked per call.

## Fix

After `PopValues` extracts results using the incremented `oldTop`, explicitly call `SetTop(oldTop - 1)` to remove the traceback function from the stack. This preserves correct result extraction while ensuring the stack is fully cleaned after each call.

Affected methods: `CallFunction`, `DoString(byte[])`, `DoString(string)`, `DoFile`.

## Reproduction

```csharp
using (var lua = new NLua.Lua())
{
    lua.UseTraceback = true;

    int topBefore = lua.State.GetTop();

    for (int i = 0; i < 10000; i++)
        lua.DoString("return 42");

    int topAfter = lua.State.GetTop();
    // Before fix: topAfter == topBefore + 10000 (leaked)
    // After fix:  topAfter == topBefore (clean)
}
```

## Tests

Added 4 new tests:
- `UseTraceback_CallFunction_NoStackLeak` — 10,000 `LuaFunction.Call()` calls, verifies stack is unchanged
- `UseTraceback_DoString_NoStackLeak` — 10,000 `DoString` calls, verifies stack is unchanged
- `UseTraceback_DoString_ReturnsCorrectValues` — multi-return with `UseTraceback=true`, verifies all values captured
- `UseTraceback_Disabled_NoStackLeak` — baseline with `UseTraceback=false`, verifies no regression

Full test suite: 187 passed, 0 failed.